### PR TITLE
Resolve Issue #26

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,9 +36,9 @@ lazy val ducktape =
   project
     .in(file("ducktape"))
     .settings(
-      scalacOptions ++= List("-Xcheck-macros", "-no-indent", "-old-syntax", "-Xfatal-warnings", "-deprecation", "-explain"),
+      scalacOptions ++= List("-Xcheck-macros", "-no-indent", "-old-syntax", "-Xfatal-warnings", "-deprecation"),
       libraryDependencies += "org.scalameta" %% "munit" % "1.0.0-M7" % Test,
-      mimaPreviousArtifacts := Set("io.github.arainko" %% "ducktape" % "0.1.0")
+      mimaPreviousArtifacts := Set("io.github.arainko" %% "ducktape" % "0.1.0", "io.github.arainko" %% "ducktape" % "0.1.1")
     )
 
 lazy val docs =

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val ducktape =
   project
     .in(file("ducktape"))
     .settings(
-      scalacOptions ++= List("-Xcheck-macros", "-no-indent", "-old-syntax", "-Xfatal-warnings", "-deprecation"),
+      scalacOptions ++= List("-Xcheck-macros", "-no-indent", "-old-syntax", "-Xfatal-warnings", "-deprecation", "-explain"),
       libraryDependencies += "org.scalameta" %% "munit" % "1.0.0-M7" % Test,
       mimaPreviousArtifacts := Set("io.github.arainko" %% "ducktape" % "0.1.0")
     )

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -23,7 +23,7 @@ final case class PersonButMoreFields(firstName: String, lastName: String, age: I
 
 val personWithMoreFields = PersonButMoreFields("John", "Doe", 30, "SOCIAL-NUM-12345")
 
-val transformed = personWithMoreFields.transformInto[Person]
+val transformed = personWithMoreFields.to[Person]
 
 ```
 
@@ -34,7 +34,7 @@ If these requirements are not met, a compiletime error is issued:
 ```scala mdoc:fail
 val person = Person("Jerry", "Smith", 20)
 
-person.transformInto[PersonButMoreFields]
+person.to[PersonButMoreFields]
 
 ```
 
@@ -49,14 +49,14 @@ enum Size:
 enum ExtraSize:
   case ExtraSmall, Small, Medium, Large, ExtraLarge
 
-val transformed = Size.Small.transformInto[ExtraSize]
+val transformed = Size.Small.to[ExtraSize]
 // transformed: ExtraSize = Small
 ```
 
 We can't go to a coproduct that doesn't contain all of our cases (name wise):
 
 ```scala
-val size = ExtraSize.Small.transformInto[Size]
+val size = ExtraSize.Small.to[Size]
 // error:
 // No child named 'ExtraSmall' in Size
 ```
@@ -234,9 +234,9 @@ final case class WrappedString(value: String) extends AnyVal
 
 val wrapped = WrappedString("I am a String")
 
-val unwrapped = wrapped.transformInto[String]
+val unwrapped = wrapped.to[String]
 
-val wrappedAgain = unwrapped.transformInto[WrappedString]
+val wrappedAgain = unwrapped.to[WrappedString]
 ```
 
 #### 8. Defining custom `Transformers`
@@ -301,16 +301,16 @@ case class EvenMoreInside2(str: String, int: Int)
 
 val person = Person(23, Some("str"), Inside("insideStr", 24, EvenMoreInside("evenMoreInsideStr", 25)), Vector.empty)
 ```
-#### Generated code - expansion of `.transformInto`
-Calling the `.transformInto` method
+#### Generated code - expansion of `.to`
+Calling the `.to` method
 ```scala mdoc:silent
-person.transformInto[Person2]
+person.to[Person2]
 ```
 expands to:
 ```scala mdoc:passthrough
 import io.github.arainko.ducktape.docs.*
 
-Docs.printCode(person.transformInto[Person2])
+Docs.printCode(person.to[Person2])
 ```
 
 #### Generated code - expansion of `.into`

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformerMacros.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformerMacros.scala
@@ -157,18 +157,22 @@ private[ducktape] final class ProductTransformerMacros(using val quotes: Quotes)
 
   private def resolveTransformation[Source: Type](sourceValue: Expr[Source], source: Field, destination: Field)(using Quotes) =
     source.transformerTo(destination) match {
+      // even though this is taken care of in LiftTransformation.liftTransformation
+      // we need to do this here due to a compiler bug where multiple matches on a
+      // Transformer[A, B >: A] the B type get replaced with `B | dest` but only if
+      // you refer to a case class defined in an object by NOT its full path (it works if you refer to it as the full path)
+      // workaround for issue: https://github.com/arainko/ducktape/issues/26 until this gets fixed in dotty.
+      case '{
+            type a
+            $transformer: Transformer.Identity[`a`, `a`]
+          } =>
+        accessField(sourceValue, source.name)
       case '{ $transformer: Transformer[source, dest] } =>
         val field = accessField(sourceValue, source.name).asExprOf[source]
-        // println()
-        // println(Type.show[dest])
-        // println(field.asTerm.tpe.widen.show)
-        // '{ $transformer.transform($field) }.asTerm
         LiftTransformation.liftTransformation(transformer, field).asTerm
     }
 
   private def accessField(value: Expr[Any], fieldName: String)(using Quotes) = Select.unique(value.asTerm, fieldName)
-
-  // Select.unique()
 
   private def constructor(tpe: TypeRepr)(using Quotes): Term = {
     val (repr, constructor, tpeArgs) = tpe match {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformerMacros.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformerMacros.scala
@@ -159,11 +159,11 @@ private[ducktape] final class ProductTransformerMacros(using val quotes: Quotes)
     source.transformerTo(destination) match {
       case '{ $transformer: Transformer[source, dest] } =>
         val field = accessField(sourceValue, source.name).asExprOf[source]
-        println()
-        println(Type.show[dest])
-        println(field.asTerm.tpe.show)
-        '{ $transformer.transform($field.asInstanceOf[source]) }.asTerm
-        // LiftTransformation.liftTransformation(transformer, field).asTerm
+        // println()
+        // println(Type.show[dest])
+        // println(field.asTerm.tpe.widen.show)
+        // '{ $transformer.transform($field) }.asTerm
+        LiftTransformation.liftTransformation(transformer, field).asTerm
     }
 
   private def accessField(value: Expr[Any], fieldName: String)(using Quotes) = Select.unique(value.asTerm, fieldName)

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformerMacros.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformerMacros.scala
@@ -159,10 +159,16 @@ private[ducktape] final class ProductTransformerMacros(using val quotes: Quotes)
     source.transformerTo(destination) match {
       case '{ $transformer: Transformer[source, dest] } =>
         val field = accessField(sourceValue, source.name).asExprOf[source]
-        LiftTransformation.liftTransformation(transformer, field).asTerm
+        println()
+        println(Type.show[dest])
+        println(field.asTerm.tpe.show)
+        '{ $transformer.transform($field.asInstanceOf[source]) }.asTerm
+        // LiftTransformation.liftTransformation(transformer, field).asTerm
     }
 
   private def accessField(value: Expr[Any], fieldName: String)(using Quotes) = Select.unique(value.asTerm, fieldName)
+
+  // Select.unique()
 
   private def constructor(tpe: TypeRepr)(using Quotes): Term = {
     val (repr, constructor, tpeArgs) = tpe match {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
@@ -10,10 +10,10 @@ import scala.deriving.Mirror
 extension [Source](value: Source) {
   def into[Dest]: AppliedBuilder[Source, Dest] = AppliedBuilder(value)
 
-  inline def transformInto[Dest](using inline transformer: Transformer[Source, Dest]) =
-    ${ LiftTransformation.liftTransformation('transformer, 'value) }
+  // TODO: Introduce in ducktape 0.2 as a replacement for `.to`, this will break binary compat
+  // inline def transformInto[Dest](using inline transformer: Transformer[Source, Dest]) =
+  //   ${ LiftTransformation.liftTransformation('transformer, 'value) }
 
-  // @deprecated(message = "Use '.transformInto' instead, it includes some additional optimizations", since = "0.1.2")
   def to[Dest](using Transformer[Source, Dest]): Dest = Transformer[Source, Dest].transform(value)
 
   transparent inline def intoVia[Func](inline function: Func)(using Mirror.ProductOf[Source], FunctionMirror[Func]) =

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
@@ -13,7 +13,7 @@ extension [Source](value: Source) {
   inline def transformInto[Dest](using inline transformer: Transformer[Source, Dest]) =
     ${ LiftTransformation.liftTransformation('transformer, 'value) }
 
-  @deprecated(message = "Use '.transformInto' instead, it includes some additional optimizations", since = "0.1.2")
+  // @deprecated(message = "Use '.transformInto' instead, it includes some additional optimizations", since = "0.1.2")
   def to[Dest](using Transformer[Source, Dest]): Dest = Transformer[Source, Dest].transform(value)
 
   transparent inline def intoVia[Func](inline function: Func)(using Mirror.ProductOf[Source], FunctionMirror[Func]) =

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue26Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue26Spec.scala
@@ -1,24 +1,33 @@
 package io.github.arainko.ducktape.issues
 
 import io.github.arainko.ducktape.*
-import io.github.arainko.ducktape.DucktapeSuite
 
 case class A(anotherCaseClass: A.AnotherCaseClass)
 
 object A {
   case class AnotherCaseClass(name: String)
-  case class B(anotherCaseClass: A.AnotherCaseClass)
+
+  // note how AnotherCaseClass is not referred to as A.AnotherCaseClass
+  case class B(anotherCaseClass: AnotherCaseClass)
 }
 
-object SomeOtherObject {
-}
-
+// https://github.com/arainko/ducktape/issues/26
 class Issue26Spec extends DucktapeSuite {
-  // import A.*
+  test("derive a correct transformer no matter how you refer to A.AnotherCaseClass inside of `A.B`") {
+    val expected = A.B(A.AnotherCaseClass("test"))
 
-  test("repro") {
     val a = A(A.AnotherCaseClass("test"))
-    val b = a.to[A.B]
+    val actual =
+      List(
+        a.to[A.B],
+        a.into[A.B].transform(),
+        a.via(A.B.apply),
+        a.intoVia(A.B.apply).transform(),
+        Transformer.define[A, A.B].build().transform(a),
+        Transformer.defineVia[A](A.B.apply).build().transform(a)
+      )
+
+    actual.foreach(actual => assertEquals(actual, expected))
   }
 
 }

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue26Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue26Spec.scala
@@ -1,0 +1,18 @@
+package io.github.arainko.ducktape.issues
+
+import io.github.arainko.ducktape.*
+import io.github.arainko.ducktape.DucktapeSuite
+
+case class A(anotherCaseClass: AnotherCaseClass)
+case class AnotherCaseClass(name: String)
+
+object A {
+  case class B(anotherCaseClass: AnotherCaseClass)
+}
+
+class Issue26Spec extends DucktapeSuite {
+  import A.*
+
+  val a = A(AnotherCaseClass("test"))
+  val b = a.to[A.B]
+}

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue26Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue26Spec.scala
@@ -3,16 +3,22 @@ package io.github.arainko.ducktape.issues
 import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.DucktapeSuite
 
-case class A(anotherCaseClass: AnotherCaseClass)
-case class AnotherCaseClass(name: String)
+case class A(anotherCaseClass: A.AnotherCaseClass)
 
 object A {
-  case class B(anotherCaseClass: AnotherCaseClass)
+  case class AnotherCaseClass(name: String)
+  case class B(anotherCaseClass: A.AnotherCaseClass)
+}
+
+object SomeOtherObject {
 }
 
 class Issue26Spec extends DucktapeSuite {
-  import A.*
+  // import A.*
 
-  val a = A(AnotherCaseClass("test"))
-  val b = a.to[A.B]
+  test("repro") {
+    val a = A(A.AnotherCaseClass("test"))
+    val b = a.to[A.B]
+  }
+
 }


### PR DESCRIPTION
* Resolves #26 

The culprit of this seems to be a weird interaction of the following:
*  quote matches that seem innocent on `Transformer[A, B]` that really is a `Transformer.Identity[A, B >: A]` (note the type bounds) underneath,
*  the placement of a one of the field case classes in an object and not referring to it with its full path

I also managed to create a reproduction for this issue which probably points to a bug in the metaprogramming facilities of Scala 3 (that I'll make sure to report):
```scala
import scala.quoted.*
import scala.deriving.Mirror

@FunctionalInterface
trait ReproTransformer[A, B] {
  def transform(from: A): B
}

object ReproTransformer {
  final class Identity[A, B >: A] extends ReproTransformer[A, B] {
    def transform(from: A): B = from
  }

  given identity[A, B >: A]: Identity[A, B] = Identity[A, B]

  inline given derived[A <: Product, B <: Product](using Mirror.ProductOf[A], Mirror.ProductOf[B]): ReproTransformer[A, B] = 
    ${ deriveProductTransformerMacro[A, B] }

  def deriveProductTransformerMacro[A: Type, B: Type](using Quotes): Expr[ReproTransformer[A, B]] =
    '{ value => ${ transformProductMacro[A, B]('value) } }

  def transformProductMacro[A: Type, B: Type](source: Expr[A])(using Quotes): Expr[B] = {
    import quotes.reflect.*

    val sourceTpe = TypeRepr.of[A]
    val destTpe = TypeRepr.of[B]

    def fields(tpe: TypeRepr) =
      tpe.typeSymbol.caseFields
        .map(sym => sym.name -> tpe.memberType(sym))
        .toMap

    def accessField(source: Expr[A], name: String) = Select.unique(source.asTerm, name)

    val sourceFields = fields(sourceTpe)
    val destFields = fields(destTpe)

    val fieldTransformations =
      sourceFields.map { (name, sourceTpe) =>
        val destTpe = destFields(name)
        (sourceTpe.asType -> destTpe.asType) match {
          case '[src] -> '[dest] =>
            val transformer = Expr.summon[ReproTransformer[src, dest]].getOrElse(report.errorAndAbort(s"Not found for $name"))
// -------------------- INTERESTING STUFF STARTS HERE
            transformer match {
              case '{ $transformer: ReproTransformer[a, b] } =>
                val field = accessField(source, name).asExprOf[a]
                NamedArg(name, '{ $transformer.transform($field) }.asTerm)
            }
// -------------------- INTERESTING STUFF ENDS HERE
        }
      }.toList

    val constructorSym = destTpe.typeSymbol.primaryConstructor
    New(Inferred(destTpe)).select(constructorSym).appliedToArgs(fieldTransformations).asExprOf[B]
  }
}
```

If we were to take our original example:
```scala
case class A(anotherCaseClass: A.AnotherCaseClass)

object A {
  case class AnotherCaseClass(name: String)

  // note how AnotherCaseClass is not referred to as A.AnotherCaseClass
  case class B(anotherCaseClass: AnotherCaseClass)
}
```

and call `ReproTransformer.derived[A, A.B]` we'd end up with the issue as in #26.

However if we were to alter the `INTERESTING` block from the example above to just this (note how I only got rid of the pattern match that shouldn't change the semantics):
```scala
// -------------------- INTERESTING STUFF STARTS HERE
            val field = accessField(source, name).asExprOf[src]
            NamedArg(name, '{ $transformer.transform($field) }.asTerm)
// -------------------- INTERESTING STUFF ENDS HERE
```
then `ReproTransformer.derived[A, A.B]` compiles fine.

The issue is resolved by special-casing quote matches on `Tranformer.Identity` in `ProductTransformerMacros` until this weird interaction is gone (?)
