### PR TITLE
fix #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If this project interests you, please drop a 🌟 - these things are worthless b
 
 ### Installation
 ```scala
-libraryDependencies += "io.github.arainko" %% "ducktape" % "0.1.3"
+libraryDependencies += "io.github.arainko" %% "ducktape" % "0.1.4"
 ```
 NOTE: the [version scheme](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html) is set to `early-semver`
 
@@ -339,13 +339,13 @@ val definedViaTransformer =
   Transformer
     .defineVia[TestClass](method)
     .build(Arg.const(_.additionalArg, List("const")))
-// definedViaTransformer: Transformer[TestClass, TestClassWithAdditionalList] = repl.MdocSession$MdocApp6$$Lambda$38661/0x0000000106842c40@680998bb
+// definedViaTransformer: Transformer[TestClass, TestClassWithAdditionalList] = repl.MdocSession$MdocApp6$$Lambda$25310/0x00000001049ae040@117b21b7
 
 val definedTransformer =
   Transformer
     .define[TestClass, TestClassWithAdditionalList]   
     .build(Field.const(_.additionalArg, List("const")))
-// definedTransformer: Transformer[TestClass, TestClassWithAdditionalList] = repl.MdocSession$MdocApp6$$Lambda$38662/0x0000000106840040@44a6c67d
+// definedTransformer: Transformer[TestClass, TestClassWithAdditionalList] = repl.MdocSession$MdocApp6$$Lambda$25311/0x00000001049ae440@3c96fd7f
 
 val transformedVia = definedViaTransformer.transform(testClass)
 // transformedVia: TestClassWithAdditionalList = TestClassWithAdditionalList(
@@ -525,28 +525,61 @@ person
 expands to:
 ``` scala 
   {
-  val x$4$proxy5: FunctionMirror[Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2]] {
-    type Return >: Person2 <: Person2
-  } = FunctionMirror.asInstanceOf[FunctionMirror[Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2]] {
-    type Return >: Person2 <: Person2
-  }]
-  val builder: AppliedViaBuilder[Person, Return, Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2], Nothing] = inline$instance[Person, x$4$proxy5.Return, Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2], Nothing](person, ((int: Wrapped[Int], str: Option[Wrapped[String]], inside: Inside2, collectionOfNumbers: List[Wrapped[Float]]) => Person2.apply(int, str, inside, collectionOfNumbers)))
-  val AppliedViaBuilder_this: AppliedViaBuilder[Person, Person2, Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2], FunctionArguments {
-    val int: Wrapped[Int]
-    val str: Option[Wrapped[String]]
-    val inside: Inside2
-    val collectionOfNumbers: List[Wrapped[Float]]
-  }] = builder.asInstanceOf[[ArgSelector >: Nothing <: FunctionArguments] => AppliedViaBuilder[Person, Return, Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2], ArgSelector][FunctionArguments {
-    val int: Wrapped[Int]
-    val str: Option[Wrapped[String]]
-    val inside: Inside2
-    val collectionOfNumbers: List[Wrapped[Float]]
-  }]]
+    val x$4$proxy5: FunctionMirror[Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2]] {
+      type Return >: Person2 <: Person2
+    } = FunctionMirror.asInstanceOf[
+      FunctionMirror[Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2]] {
+        type Return >: Person2 <: Person2
+      }
+    ]
+    val builder: AppliedViaBuilder[Person, Return, Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[
+      Wrapped[Float]
+    ], Person2], Nothing] = inline$instance[Person, x$4$proxy5.Return, Function4[Wrapped[Int], Option[
+      Wrapped[String]
+    ], Inside2, List[Wrapped[Float]], Person2], Nothing](
+      person,
+      (int: Wrapped[Int], str: Option[Wrapped[String]], inside: Inside2, collectionOfNumbers: List[Wrapped[Float]]) =>
+        Person2.apply(int, str, inside, collectionOfNumbers)
+    )
+    val AppliedViaBuilder_this: AppliedViaBuilder[
+      Person,
+      Person2,
+      Function4[Wrapped[Int], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2],
+      FunctionArguments {
+        val int: Wrapped[Int]
+        val str: Option[Wrapped[String]]
+        val inside: Inside2
+        val collectionOfNumbers: List[Wrapped[Float]]
+      }
+    ] =
+      builder.asInstanceOf[[ArgSelector >: Nothing <: FunctionArguments] =>> AppliedViaBuilder[Person, Return, Function4[Wrapped[
+        Int
+      ], Option[Wrapped[String]], Inside2, List[Wrapped[Float]], Person2], ArgSelector][
+        FunctionArguments {
+          val int: Wrapped[Int]
+          val str: Option[Wrapped[String]]
+          val inside: Inside2
+          val collectionOfNumbers: List[Wrapped[Float]]
+        }
+      ]]
 
-  ({
-    val source$proxy15: Person = AppliedViaBuilder_this.inline$source
+    {
+      val source$proxy15: Person = AppliedViaBuilder_this.inline$source
 
-    (AppliedViaBuilder_this.inline$function.apply(Wrapped.apply[Int](source$proxy15.int.+(100)), Some.apply[Wrapped[String]](Wrapped.apply[String]("ConstStr!")), new Inside2(int = source$proxy15.inside.int, str = source$proxy15.inside.str, inside = Some.apply[EvenMoreInside2](new EvenMoreInside2(str = source$proxy15.inside.inside.str, int = source$proxy15.inside.inside.int))), source$proxy15.collectionOfNumbers.map[Wrapped[Float]](((src: Float) => new Wrapped[Float](src))).to[List[Wrapped[Float]] & Iterable[Wrapped[Float]]](iterableFactory[Wrapped[Float]])): Person2)
-  }: Person2)
-}
+      AppliedViaBuilder_this.inline$function.apply(
+        Wrapped.apply[Int](source$proxy15.int.+(100)),
+        Some.apply[Wrapped[String]](Wrapped.apply[String]("ConstStr!")),
+        new Inside2(
+          int = source$proxy15.inside.int,
+          str = source$proxy15.inside.str,
+          inside = Some.apply[EvenMoreInside2](
+            new EvenMoreInside2(str = source$proxy15.inside.inside.str, int = source$proxy15.inside.inside.int)
+          )
+        ),
+        source$proxy15.collectionOfNumbers
+          .map[Wrapped[Float]]((src: Float) => new Wrapped[Float](src))
+          .to[List[Wrapped[Float]] & Iterable[Wrapped[Float]]](iterableFactory[Wrapped[Float]])
+      ): Person2
+    }: Person2
+  }
 ```

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/LiftTransformation.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/LiftTransformation.scala
@@ -102,7 +102,13 @@ private[ducktape] object LiftTransformation {
           tl.methodArgs
             .map(replacer.apply) // replace all references to the lambda param
             .map(transformTransformerInvocation) // recurse down into nested calls
-        Apply(tl.methodCall, newArgs)
+
+        tl.defs match {
+          case Nil =>
+            Apply(tl.methodCall, newArgs)
+          case nonEmpty =>
+            Inlined(None, nonEmpty, Apply(tl.methodCall, newArgs))
+        }
 
       case tl: TransformerLambda.ToAnyVal[quotes.type] =>
         Apply(tl.constructorCall, List(appliedTo.asTerm))

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MakeTransformer.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MakeTransformer.scala
@@ -1,19 +1,33 @@
 package io.github.arainko.ducktape.internal.modules
 
+import scala.annotation.tailrec
 import scala.quoted.*
 
 private[ducktape] object MakeTransformer {
 
-  def unapply(using Quotes)(term: quotes.reflect.Term): Option[(quotes.reflect.ValDef, quotes.reflect.Term)] = {
+  /**
+   * Tries to match on `Transformer.ForProduct.make(param => body)` (or any of the special cased Transformers that have a `make` method)
+   * and extract `param` and `body` of the lambda along with definitions introduced in traversed `Inlined` nodes in case these are used in the AST.
+   */
+  def unapply(using Quotes)(
+    term: quotes.reflect.Term
+  ): Option[(quotes.reflect.ValDef, List[quotes.reflect.Definition], quotes.reflect.Term)] = {
     import quotes.reflect.*
 
-    term match {
-      case Inlined(_, Nil, term) =>
-        unapply(term)
-      case Untyped(Apply(_, List(Uninlined(Untyped(Uninlined(Lambda(List(param), Uninlined(body)))))))) =>
-        Some(param -> body)
-      case other =>
-        None
-    }
+    @tailrec
+    def recurse(
+      term: quotes.reflect.Term,
+      defAcc: List[quotes.reflect.Definition]
+    ): Option[(quotes.reflect.ValDef, List[quotes.reflect.Definition], quotes.reflect.Term)] =
+      term match {
+        case Inlined(_, defs, term) =>
+          recurse(term, defAcc ::: defs)
+        case Untyped(Apply(_, List(Uninlined(Untyped(Uninlined(Lambda(List(param), Uninlined(body)))))))) =>
+          Some((param, defAcc, body))
+        case other =>
+          None
+      }
+
+    recurse(term, Nil)
   }
 }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/TransformerLambda.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/TransformerLambda.scala
@@ -14,6 +14,7 @@ private[ducktape] object TransformerLambda {
 
   final class ForProduct[Q <: Quotes & Singleton](using val quotes: Q)(
     val param: quotes.reflect.ValDef,
+    val defs: List[quotes.reflect.Definition],
     val methodCall: quotes.reflect.Term,
     val methodArgs: List[quotes.reflect.Term]
   ) extends TransformerLambda[Q]
@@ -55,8 +56,10 @@ private[ducktape] object TransformerLambda {
     import quotes.reflect.*
 
     PartialFunction.condOpt(expr.asTerm) {
-      case MakeTransformer(param, Untyped(Apply(method, methodArgs))) =>
-        TransformerLambda.ForProduct(param, method, methodArgs)
+      case MakeTransformer(param, defs, Untyped(Apply(method, methodArgs))) =>
+        TransformerLambda.ForProduct(param, defs, method, methodArgs)
+      case MakeTransformer(param, defs, Block(Nil, Uninlined(Apply(method, methodArgs)))) =>
+        TransformerLambda.ForProduct(param, defs, method, methodArgs)
     }
   }
 
@@ -75,7 +78,7 @@ private[ducktape] object TransformerLambda {
     import quotes.reflect.*
 
     PartialFunction.condOpt(expr.asTerm) {
-      case MakeTransformer(param, Untyped(Block(_, Uninlined(Apply(Untyped(constructorCall), List(arg)))))) =>
+      case MakeTransformer(param, defs, Untyped(Block(_, Uninlined(Apply(Untyped(constructorCall), List(arg)))))) =>
         TransformerLambda.ToAnyVal(param, constructorCall, arg)
     }
   }
@@ -95,7 +98,7 @@ private[ducktape] object TransformerLambda {
     import quotes.reflect.*
 
     PartialFunction.condOpt(expr.asTerm) {
-      case MakeTransformer(param, Untyped(Block(_, Uninlined(Select(Untyped(_: Ident), fieldName))))) =>
+      case MakeTransformer(param, defs, Untyped(Block(_, Uninlined(Select(Untyped(_: Ident), fieldName))))) =>
         TransformerLambda.FromAnyVal(param, fieldName)
     }
   }

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue41Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue41Spec.scala
@@ -1,0 +1,50 @@
+package io.github.arainko.ducktape.issues
+
+import io.github.arainko.ducktape.macros.AstInstanceCounter
+import io.github.arainko.ducktape.{ DucktapeSuite, Transformer }
+
+// https://github.com/arainko/ducktape/issues/41
+class Issue41Spec extends DucktapeSuite {
+
+  test("Nested transformers are optimized away when case class' companion doesn't have vals inside") {
+    final case class TestClass(value: String, in: Inside)
+    final case class Inside(str: String)
+
+    final case class TestClass2(value: String, in: Inside2)
+    final case class Inside2(str: String)
+
+    val roughAstCount = AstInstanceCounter.roughlyCount[Transformer[?, ?]](summon[Transformer[TestClass, TestClass2]])
+    assert(roughAstCount == 10)
+  }
+
+  test("Nested transformers are optimized away when case class' companion has vals inside") {
+    final case class TestClass(value: String, in: Inside)
+
+    object TestClass {
+      val a = 1
+    }
+
+    final case class Inside(str: String)
+
+    object Inside {
+      val a = 1
+    }
+
+    final case class TestClass2(value: String, in: Inside2)
+
+    object TestClass2 {
+      val a = 1
+    }
+
+    final case class Inside2(str: String)
+
+    object Inside2 {
+      val a = 1
+    }
+
+    val roughAstCount =
+      AstInstanceCounter.roughlyCount[Transformer[?, ?]](summon[Transformer[TestClass, TestClass2]])
+
+    assert(roughAstCount == 10)
+  }
+}

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/macros/AstInstanceCounter.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/macros/AstInstanceCounter.scala
@@ -1,0 +1,35 @@
+package io.github.arainko.ducktape.macros
+
+import scala.quoted.*
+
+object AstInstanceCounter {
+
+  /**
+   * Counts how many times a Term with a given type appears in the AST.
+   * Note that a single instance can be counted multiple times due to how the tree is traversed, hence 'roughly' in the name.
+   *
+   * The way to really use it is measure how many instances you get before doing something with the AST and inspecting it and then
+   * running it after inspecting manually to have a rough ballpark of what this should be.
+   *
+   * If a test fails because the number of instances is bigger than expected it is an alert for the maintainer to inspect the AST and
+   * make a call - something akin to a fire alarm, right.
+   */
+  inline def roughlyCount[A](inline value: Any): Int = ${ impl[A]('value) }
+
+  def impl[A: Type](expr: Expr[Any])(using Quotes) = {
+    import quotes.reflect.*
+    val tpe = TypeRepr.of[A]
+
+    val acc = new TreeAccumulator[Int] {
+      override def foldTree(x: Int, tree: Tree)(owner: Symbol): Int =
+        tree match {
+          case term: Term if term.tpe <:< tpe =>
+            foldOverTree(x + 1, term)(owner)
+          case other =>
+            foldOverTree(x, other)(owner)
+        }
+    }
+
+    Expr(acc.foldOverTree(0, expr.asTerm)(Symbol.spliceOwner))
+  }
+}


### PR DESCRIPTION
Closes #41

nested transformations for case classes with companions that contain values are now optimized as well as their val-less counterparts (modulo the presence of its Mirror in the generated code - I do not dare fighting the compiler on this one)

also fixes rendering of type lambdas in docs so that scalafmt doesn't yell at me and actually let's me format the code