### PR TITLE
[Issue#37] Fix anyval transformers and standardize instance names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ ThisBuild / developers := List(
     url("https://github.com/arainko")
   )
 )
-ThisBuild / scalaVersion := "3.2.1"
+ThisBuild / scalaVersion := "3.2.2"
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
 ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,9 @@ lazy val previousArtifacts =
   Set(
     "io.github.arainko" %% "ducktape" % "0.1.0",
     "io.github.arainko" %% "ducktape" % "0.1.1",
-    "io.github.arainko" %% "ducktape" % "0.1.2"
+    "io.github.arainko" %% "ducktape" % "0.1.2",
+    "io.github.arainko" %% "ducktape" % "0.1.3",
+    "io.github.arainko" %% "ducktape" % "0.1.4",
   )
 
 lazy val root =

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
@@ -23,6 +23,103 @@ object Transformer {
     inline def showCode[A](inline value: A): A = DebugMacros.code(value)
   }
 
+  given identity[Source, Dest >: Source]: Identity[Source, Dest] = Identity[Source, Dest]
+
+  given betweenNonOptionOption[Source, Dest](using Transformer[Source, Dest]): Transformer[Source, Option[Dest]] =
+    from => Transformer[Source, Dest].transform.andThen(Some.apply)(from)
+
+  given betweenOptions[Source, Dest](using
+    Transformer[Source, Dest]
+  ): Transformer[Option[Source], Option[Dest]] =
+    from => from.map(Transformer[Source, Dest].transform)
+
+  given betweenCollections[Source, Dest, SourceCollection[elem] <: Iterable[elem], DestCollection[elem] <: Iterable[elem]](using
+    transformer: Transformer[Source, Dest],
+    factory: Factory[Dest, DestCollection[Dest]]
+  ): Transformer[SourceCollection[Source], DestCollection[Dest]] = from => from.map(transformer.transform).to(factory)
+
+  given betweenEithers[Source1, Source2, Dest1, Dest2](using
+    Transformer[Source1, Source2],
+    Transformer[Dest1, Dest2]
+  ): Transformer[Either[Source1, Dest1], Either[Source2, Dest2]] = {
+    case Right(value) => Right(Transformer[Dest1, Dest2].transform(value))
+    case Left(value)  => Left(Transformer[Source1, Source2].transform(value))
+  }
+
+  inline given betweenProducts[Source, Dest](using
+    Mirror.ProductOf[Source],
+    Mirror.ProductOf[Dest]
+  ): Transformer.ForProduct[Source, Dest] =
+    Transformer.ForProduct.make(DerivedTransformers.product[Source, Dest])
+
+  inline given betweenCoproducts[Source, Dest](using
+    Mirror.SumOf[Source],
+    Mirror.SumOf[Dest]
+  ): Transformer.ForCoproduct[Source, Dest] =
+    Transformer.ForCoproduct.make(DerivedTransformers.coproduct[Source, Dest])
+
+  inline given betweenUnwrappedWrapped[Source, Dest](using
+    Dest <:< AnyVal,
+    Dest <:< Product
+  ): Transformer.ToAnyVal[Source, Dest] =
+    Transformer.ToAnyVal.make(DerivedTransformers.toAnyVal[Source, Dest])
+
+  inline given betweenWrappedUnwrapped[Source, Dest](using
+    Source <:< AnyVal,
+    Source <:< Product
+  ): Transformer.FromAnyVal[Source, Dest] =
+    Transformer.FromAnyVal.make(DerivedTransformers.fromAnyVal[Source, Dest])
+
+  @deprecated(message = "Use 'Transformer.identity' instead", since = "0.1.5")
+  final def given_Identity_Source_Dest[Source, Dest >: Source]: Identity[Source, Dest] = identity[Source, Dest]
+
+  @deprecated(message = "Use 'Transformer.betweenProducts' instead", since = "0.1.5")
+  inline def forProducts[Source, Dest](using Mirror.ProductOf[Source], Mirror.ProductOf[Dest]): ForProduct[Source, Dest] =
+    ForProduct.make(DerivedTransformers.product[Source, Dest])
+
+  @deprecated(message = "Use 'Transformer.betweenCoproducts' instead", since = "0.1.5")
+  inline def forCoproducts[Source, Dest](using Mirror.SumOf[Source], Mirror.SumOf[Dest]): ForCoproduct[Source, Dest] =
+    ForCoproduct.make(DerivedTransformers.coproduct[Source, Dest])
+
+  @deprecated(message = "Use 'Transformer.betweenNonOptionOption' instead", since = "0.1.5")
+  final def given_Transformer_Source_Option[Source, Dest](using Transformer[Source, Dest]): Transformer[Source, Option[Dest]] =
+    betweenNonOptionOption[Source, Dest]
+
+  @deprecated(message = "Use 'Transformer.betweenOptions' instead", since = "0.1.5")
+  final def given_Transformer_Option_Option[Source, Dest](using
+    Transformer[Source, Dest]
+  ): Transformer[Option[Source], Option[Dest]] =
+    from => from.map(Transformer[Source, Dest].transform)
+
+  @deprecated(message = "Use 'Transformer.betweenEithers' instead", since = "0.1.5")
+  final def given_Transformer_Either_Either[A1, A2, B1, B2](using
+    Transformer[A1, A2],
+    Transformer[B1, B2]
+  ): Transformer[Either[A1, B1], Either[A2, B2]] = {
+    case Right(value) => Right(Transformer[B1, B2].transform(value))
+    case Left(value)  => Left(Transformer[A1, A2].transform(value))
+  }
+
+  @deprecated(message = "Use 'Transformer.betweenCollections' instead", since = "0.1.5")
+  final def given_Transformer_SourceCollection_DestCollection[
+    Source,
+    Dest,
+    SourceCollection[elem] <: Iterable[elem],
+    DestCollection[elem] <: Iterable[elem]
+  ](using
+    trans: Transformer[Source, Dest],
+    factory: Factory[Dest, DestCollection[Dest]]
+  ): Transformer[SourceCollection[Source], DestCollection[Dest]] =
+    betweenCollections[Source, Dest, SourceCollection, DestCollection]
+
+  @deprecated(message = "Use 'Transformer.betweenUnwrappedWrapped' instead", since = "0.1.5")
+  inline def fromAnyVal[Source <: AnyVal, Dest]: FromAnyVal[Source, Dest] =
+    FromAnyVal.make(DerivedTransformers.fromAnyVal[Source, Dest])
+
+  @deprecated(message = "Use 'Transformer.betweenWrappedUnwrapped' instead", since = "0.1.5")
+  inline def toAnyVal[Source, Dest <: AnyVal]: ToAnyVal[Source, Dest] =
+    ToAnyVal.make(DerivedTransformers.toAnyVal[Source, Dest])
+
   final class Identity[Source, Dest >: Source] private[Transformer] extends Transformer[Source, Dest] {
     def transform(from: Source): Dest = from
   }
@@ -57,7 +154,7 @@ object Transformer {
       }
   }
 
-  sealed trait FromAnyVal[Source <: AnyVal, Dest] extends Transformer[Source, Dest]
+  sealed trait FromAnyVal[Source, Dest] extends Transformer[Source, Dest]
 
   object FromAnyVal {
     @deprecated(message = "Use the variant with a Transformer instead", since = "0.1.1")
@@ -66,13 +163,13 @@ object Transformer {
         def transform(from: Source): Dest = f(from)
       }
 
-    private[ducktape] def make[Source <: AnyVal, Dest](transformer: Transformer[Source, Dest]): FromAnyVal[Source, Dest] =
+    private[ducktape] def make[Source, Dest](transformer: Transformer[Source, Dest]): FromAnyVal[Source, Dest] =
       new {
         def transform(from: Source): Dest = transformer.transform(from)
       }
   }
 
-  sealed trait ToAnyVal[Source, Dest <: AnyVal] extends Transformer[Source, Dest]
+  sealed trait ToAnyVal[Source, Dest] extends Transformer[Source, Dest]
 
   object ToAnyVal {
     @deprecated(message = "Use the variant with a Transformer instead", since = "0.1.1")
@@ -81,106 +178,9 @@ object Transformer {
         def transform(from: Source): Dest = f(from)
       }
 
-    private[ducktape] def make[Source, Dest <: AnyVal](transformer: Transformer[Source, Dest]): ToAnyVal[Source, Dest] =
+    private[ducktape] def make[Source, Dest](transformer: Transformer[Source, Dest]): ToAnyVal[Source, Dest] =
       new {
         def transform(from: Source): Dest = transformer.transform(from)
       }
   }
-
-  @deprecated(message = "Use 'Transformer.identity' instead", since = "0.1.5")
-  final def given_Identity_Source_Dest[Source, Dest >: Source]: Identity[Source, Dest] = identity[Source, Dest]
-
-  given identity[Source, Dest >: Source]: Identity[Source, Dest] = Identity[Source, Dest]
-
-  @deprecated(message = "Use 'Transformer.betweenProducts' instead", since = "0.1.5")
-  inline def forProducts[Source, Dest](using Mirror.ProductOf[Source], Mirror.ProductOf[Dest]): ForProduct[Source, Dest] =
-    ForProduct.make(DerivedTransformers.product[Source, Dest])
-
-  @deprecated(message = "Use 'Transformer.betweenCoproducts' instead", since = "0.1.5")
-  inline def forCoproducts[Source, Dest](using Mirror.SumOf[Source], Mirror.SumOf[Dest]): ForCoproduct[Source, Dest] =
-    ForCoproduct.make(DerivedTransformers.coproduct[Source, Dest])
-
-  inline given betweenProducts[Source, Dest](using
-    Mirror.ProductOf[Source],
-    Mirror.ProductOf[Dest]
-  ): Transformer.ForProduct[Source, Dest] =
-    Transformer.ForProduct.make(DerivedTransformers.product[Source, Dest])
-
-  inline given betweenCoproducts[Source, Dest](using
-    Mirror.SumOf[Source],
-    Mirror.SumOf[Dest]
-  ): Transformer.ForCoproduct[Source, Dest] =
-    Transformer.ForCoproduct.make(DerivedTransformers.coproduct[Source, Dest])
-
-  @deprecated(message = "Use 'Transformer.betweenNonOptionOption' instead", since = "0.1.5")
-  final def given_Transformer_Source_Option[Source, Dest](using Transformer[Source, Dest]): Transformer[Source, Option[Dest]] =
-    betweenNonOptionOption[Source, Dest]
-
-  given betweenNonOptionOption[Source, Dest](using Transformer[Source, Dest]): Transformer[Source, Option[Dest]] =
-    from => Transformer[Source, Dest].transform.andThen(Some.apply)(from)
-
-  @deprecated(message = "Use 'Transformer.betweenOptions' instead", since = "0.1.5")
-  final def given_Transformer_Option_Option[Source, Dest](using
-    Transformer[Source, Dest]
-  ): Transformer[Option[Source], Option[Dest]] =
-    from => from.map(Transformer[Source, Dest].transform)
-
-  given betweenOptions[Source, Dest](using
-    Transformer[Source, Dest]
-  ): Transformer[Option[Source], Option[Dest]] =
-    from => from.map(Transformer[Source, Dest].transform)
-
-  @deprecated(message = "Use 'Transformer.betweenEithers' instead", since = "0.1.5")
-  final def given_Transformer_Either_Either[A1, A2, B1, B2](using
-    Transformer[A1, A2],
-    Transformer[B1, B2]
-  ): Transformer[Either[A1, B1], Either[A2, B2]] = {
-    case Right(value) => Right(Transformer[B1, B2].transform(value))
-    case Left(value)  => Left(Transformer[A1, A2].transform(value))
-  }
-
-  given betweenEithers[A1, A2, B1, B2](using
-    Transformer[A1, A2],
-    Transformer[B1, B2]
-  ): Transformer[Either[A1, B1], Either[A2, B2]] = {
-    case Right(value) => Right(Transformer[B1, B2].transform(value))
-    case Left(value)  => Left(Transformer[A1, A2].transform(value))
-  }
-
-  @deprecated(message = "Use 'Transformer.betweenCollections' instead", since = "0.1.5")
-  final def given_Transformer_SourceCollection_DestCollection[
-    Source,
-    Dest,
-    SourceCollection[elem] <: Iterable[elem],
-    DestCollection[elem] <: Iterable[elem]
-  ](using
-    trans: Transformer[Source, Dest],
-    factory: Factory[Dest, DestCollection[Dest]]
-  ): Transformer[SourceCollection[Source], DestCollection[Dest]] =
-    betweenCollections[Source, Dest, SourceCollection, DestCollection]
-
-  given betweenCollections[Source, Dest, SourceCollection[elem] <: Iterable[elem], DestCollection[elem] <: Iterable[elem]](using
-    trans: Transformer[Source, Dest],
-    factory: Factory[Dest, DestCollection[Dest]]
-  ): Transformer[SourceCollection[Source], DestCollection[Dest]] = from => from.map(trans.transform).to(factory)
-
-  @deprecated
-  inline def fromAnyVal[Source <: AnyVal, Dest]: FromAnyVal[Source, Dest] =
-    FromAnyVal.make(DerivedTransformers.fromAnyVal[Source, Dest])
-
-  @deprecated
-  inline def toAnyVal[Source, Dest <: AnyVal]: ToAnyVal[Source, Dest] =
-    ToAnyVal.make(DerivedTransformers.toAnyVal[Source, Dest])
-
-  inline given costamToAnyVal[Source, Dest](using
-    Dest <:< AnyVal,
-    Dest <:< Product
-  ): Transformer.ToAnyVal[Source, Dest] =
-    Transformer.ToAnyVal.make(DerivedTransformers.toAnyVal[Source, Dest])
-
-  inline given costamFromAnyVal[Source <: AnyVal, Dest](using
-    Source <:< AnyVal,
-    Source <:< Product
-  ): Transformer.FromAnyVal[Source, Dest] =
-    Transformer.FromAnyVal.make(DerivedTransformers.fromAnyVal[Source, Dest])
 }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/DerivedTransformers.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/DerivedTransformers.scala
@@ -30,15 +30,15 @@ private[ducktape] object DerivedTransformers {
   )(using Quotes): Expr[Transformer[Source, Dest]] =
     '{ source => ${ CoproductTransformations.transform[Source, Dest]('source, Source, Dest) } }
 
-  inline def toAnyVal[Source, Dest <: AnyVal]: Transformer[Source, Dest] =
+  inline def toAnyVal[Source, Dest]: Transformer[Source, Dest] =
     ${ deriveToAnyValTransformerMacro[Source, Dest] }
 
-  def deriveToAnyValTransformerMacro[Source: Type, Dest <: AnyVal: Type](using Quotes): Expr[Transformer[Source, Dest]] =
+  def deriveToAnyValTransformerMacro[Source: Type, Dest: Type](using Quotes): Expr[Transformer[Source, Dest]] =
     '{ source => ${ ProductTransformations.transformToAnyVal('source) } }
 
-  inline def fromAnyVal[Source <: AnyVal, Dest] =
+  inline def fromAnyVal[Source, Dest] =
     ${ deriveFromAnyValTransformerMacro[Source, Dest] }
 
-  def deriveFromAnyValTransformerMacro[Source <: AnyVal: Type, Dest: Type](using Quotes): Expr[Transformer[Source, Dest]] =
+  def deriveFromAnyValTransformerMacro[Source: Type, Dest: Type](using Quotes): Expr[Transformer[Source, Dest]] =
     '{ source => ${ ProductTransformations.transformFromAnyVal('source) } }
 }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/LiftTransformation.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/LiftTransformation.scala
@@ -36,12 +36,12 @@ private[ducktape] object LiftTransformation {
     appliedTo: Expr[A]
   )(using Quotes): Option[Expr[B]] =
     PartialFunction.condOpt(transformer) {
-      case '{ Transformer.given_Transformer_Source_Option[source, dest](using $transformer) } =>
+      case '{ Transformer.betweenNonOptionOption[source, dest](using $transformer) } =>
         val field = appliedTo.asExprOf[source]
         val lifted = liftTransformation(transformer, field)
         '{ Some($lifted) }.asExprOf[B]
 
-      case '{ Transformer.given_Transformer_Option_Option[source, dest](using $transformer) } =>
+      case '{ Transformer.betweenOptions[source, dest](using $transformer) } =>
         val field = appliedTo.asExprOf[Option[source]]
         '{ $field.map(src => ${ liftTransformation(transformer, 'src) }) }.asExprOf[B]
 
@@ -50,7 +50,7 @@ private[ducktape] object LiftTransformation {
       // https://github.com/lampepfl/dotty/discussions/12446
       // Because of that we need to do some more shenanigans to get the exact collection type we transform into
       case '{
-            Transformer.given_Transformer_SourceCollection_DestCollection[
+            Transformer.betweenCollections[
               source,
               dest,
               Iterable,

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformations.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformations.scala
@@ -111,6 +111,8 @@ private[ducktape] object ProductTransformations {
   )(using Quotes): Expr[Dest] = {
     import quotes.reflect.*
 
+    println(s"FROM ANY VAL: ${Type.show[Source]} ${Type.show[Dest]}")
+
     val tpe = TypeRepr.of[Source]
     val fieldSymbol =
       tpe.typeSymbol.fieldMembers.headOption
@@ -123,6 +125,8 @@ private[ducktape] object ProductTransformations {
     sourceValue: Expr[Source]
   )(using Quotes): Expr[Dest] = {
     import quotes.reflect.*
+
+    println(s"TO ANY VAL: ${Type.show[Source]} ${Type.show[Dest]}")
 
     constructor(TypeRepr.of[Dest])
       .appliedTo(sourceValue.asTerm)

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformations.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformations.scala
@@ -106,12 +106,10 @@ private[ducktape] object ProductTransformations {
       .asExprOf[Dest]
   }
 
-  def transformFromAnyVal[Source <: AnyVal: Type, Dest: Type](
+  def transformFromAnyVal[Source: Type, Dest: Type](
     sourceValue: Expr[Source]
   )(using Quotes): Expr[Dest] = {
     import quotes.reflect.*
-
-    println(s"FROM ANY VAL: ${Type.show[Source]} ${Type.show[Dest]}")
 
     val tpe = TypeRepr.of[Source]
     val fieldSymbol =
@@ -121,12 +119,10 @@ private[ducktape] object ProductTransformations {
     accessField(sourceValue, fieldSymbol.name).asExprOf[Dest]
   }
 
-  def transformToAnyVal[Source: Type, Dest <: AnyVal: Type](
+  def transformToAnyVal[Source: Type, Dest: Type](
     sourceValue: Expr[Source]
   )(using Quotes): Expr[Dest] = {
     import quotes.reflect.*
-
-    println(s"TO ANY VAL: ${Type.show[Source]} ${Type.show[Dest]}")
 
     constructor(TypeRepr.of[Dest])
       .appliedTo(sourceValue.asTerm)

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue37Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue37Spec.scala
@@ -3,10 +3,16 @@ package io.github.arainko.ducktape.issues
 import io.github.arainko.ducktape.*
 
 // https://github.com/arainko/ducktape/issues/37
-class Issue37Spec extends DucktapeSuite { 
+class Issue37Spec extends DucktapeSuite {
   final case class Rec[A](value: A, rec: Option[Rec[A]])
 
-  given rec[A,B](using Transformer[A, B]): Transformer[Rec[A], Rec[B]] = Transformer.define[Rec[A], Rec[B]].build()
+  given rec[A, B](using Transformer[A, B]): Transformer[Rec[A], Rec[B]] = Transformer.define[Rec[A], Rec[B]].build()
 
-  rec[Int, Option[Int]] // Failed to fetch the wrapped field name of scala.Int
+  test("value class transformers don't interfere with primitives") {
+    val actual = rec[Int, Option[Int]].transform(Rec(1, Some(Rec(2, None))))
+    val expected: Rec[Option[Int]] = Rec(Some(1), Some(Rec(Some(2), None)))
+
+    assertEquals(actual, expected)
+  }
+
 }

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue37Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue37Spec.scala
@@ -1,0 +1,12 @@
+package io.github.arainko.ducktape.issues
+
+import io.github.arainko.ducktape.*
+
+// https://github.com/arainko/ducktape/issues/37
+class Issue37Spec extends DucktapeSuite { 
+  final case class Rec[A](value: A, rec: Option[Rec[A]])
+
+  given rec[A,B](using Transformer[A, B]): Transformer[Rec[A], Rec[B]] = Transformer.define[Rec[A], Rec[B]].build()
+
+  rec[Int, Option[Int]] // Failed to fetch the wrapped field name of scala.Int
+}

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue41Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue41Spec.scala
@@ -14,7 +14,7 @@ class Issue41Spec extends DucktapeSuite {
     final case class Inside2(str: String)
 
     val roughAstCount = AstInstanceCounter.roughlyCount[Transformer[?, ?]](summon[Transformer[TestClass, TestClass2]])
-    assert(roughAstCount == 10)
+    assert(clue(roughAstCount) == 10)
   }
 
   test("Nested transformers are optimized away when case class' companion has vals inside") {
@@ -45,6 +45,6 @@ class Issue41Spec extends DucktapeSuite {
     val roughAstCount =
       AstInstanceCounter.roughlyCount[Transformer[?, ?]](summon[Transformer[TestClass, TestClass2]])
 
-    assert(roughAstCount == 10)
+    assert(clue(roughAstCount) == 10)
   }
 }

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/macros/MakeTransformerSpec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/macros/MakeTransformerSpec.scala
@@ -10,16 +10,16 @@ import scala.quoted.*
 
 class MakeTransformerSpec extends DucktapeSuite {
 
-  // test("should match ForProduct.make") {
-  //   MakeTransformerChecker.check(Transformer.forProducts[ComplexPerson, PrimitivePerson])
-  // }
+  test("should match ForProduct.make") {
+    MakeTransformerChecker.check(Transformer.betweenProducts[ComplexPerson, PrimitivePerson])
+  }
 
   test("should match FromAnyVal.make") {
-    MakeTransformerChecker.check(Transformer.fromAnyVal[Hobby, String])
+    MakeTransformerChecker.check(Transformer.betweenWrappedUnwrapped[Hobby, String])
   }
 
   test("should match ToAnyVal.make") {
-    MakeTransformerChecker.check(Transformer.toAnyVal[String, Hobby])
+    MakeTransformerChecker.check(Transformer.betweenUnwrappedWrapped[String, Hobby])
   }
 
 }

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/macros/MakeTransformerSpec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/macros/MakeTransformerSpec.scala
@@ -10,9 +10,9 @@ import scala.quoted.*
 
 class MakeTransformerSpec extends DucktapeSuite {
 
-  test("should match ForProduct.make") {
-    MakeTransformerChecker.check(Transformer.forProducts[ComplexPerson, PrimitivePerson])
-  }
+  // test("should match ForProduct.make") {
+  //   MakeTransformerChecker.check(Transformer.forProducts[ComplexPerson, PrimitivePerson])
+  // }
 
   test("should match FromAnyVal.make") {
     MakeTransformerChecker.check(Transformer.fromAnyVal[Hobby, String])

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/macros/TransformerLambdaSpec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/macros/TransformerLambdaSpec.scala
@@ -5,9 +5,9 @@ import io.github.arainko.ducktape.macros.TransformerLambdaChecker
 import io.github.arainko.ducktape.model.*
 
 class TransformerLambdaSpec extends DucktapeSuite {
-  test("should match ForProduct") {
-    TransformerLambdaChecker.check[Transformer.ForProduct.type](Transformer.forProducts[ComplexPerson, PrimitivePerson])
-  }
+  // test("should match ForProduct") {
+  //   TransformerLambdaChecker.check[Transformer.ForProduct.type](Transformer.forProducts[ComplexPerson, PrimitivePerson])
+  // }
 
   test("should match FromAnyVal") {
     TransformerLambdaChecker

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/macros/TransformerLambdaSpec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/macros/TransformerLambdaSpec.scala
@@ -5,16 +5,16 @@ import io.github.arainko.ducktape.macros.TransformerLambdaChecker
 import io.github.arainko.ducktape.model.*
 
 class TransformerLambdaSpec extends DucktapeSuite {
-  // test("should match ForProduct") {
-  //   TransformerLambdaChecker.check[Transformer.ForProduct.type](Transformer.forProducts[ComplexPerson, PrimitivePerson])
-  // }
+  test("should match ForProduct") {
+    TransformerLambdaChecker.check[Transformer.ForProduct.type](Transformer.betweenProducts[ComplexPerson, PrimitivePerson])
+  }
 
   test("should match FromAnyVal") {
     TransformerLambdaChecker
-      .check[Transformer.FromAnyVal.type](Transformer.fromAnyVal[Hobby, String])
+      .check[Transformer.FromAnyVal.type](Transformer.betweenWrappedUnwrapped[Hobby, String])
   }
 
   test("should match ToAnyVal") {
-    TransformerLambdaChecker.check[Transformer.ToAnyVal.type](Transformer.toAnyVal[String, Hobby])
+    TransformerLambdaChecker.check[Transformer.ToAnyVal.type](Transformer.betweenUnwrappedWrapped[String, Hobby])
   }
 }


### PR DESCRIPTION
Fixes #37

* Value class transformers and transformers for primitives will not collide anymore which should result in nicer error messages in general (the compiler always fellback onto `toAnyVal` or `fromAnyVal`)
* standardized instance names with a `between` prefix and a description of types a given transformer transform between (eg. `betweenOptions`)