### PR TITLE
beta reduce function applies in .fallibleVia

### DIFF
--- a/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
@@ -3,8 +3,7 @@ package io.github.arainko.ducktape
 import io.github.arainko.ducktape.builder.*
 import io.github.arainko.ducktape.internal.macros.*
 
-import scala.collection.{ BuildFrom, Factory }
-import scala.compiletime.*
+import scala.collection.Factory
 import scala.deriving.Mirror
 
 @FunctionalInterface

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/builder/AppliedViaBuilder.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/builder/AppliedViaBuilder.scala
@@ -6,7 +6,6 @@ import io.github.arainko.ducktape.fallible.Mode.{ Accumulating, FailFast }
 import io.github.arainko.ducktape.function.*
 import io.github.arainko.ducktape.internal.macros.*
 
-import scala.compiletime.*
 import scala.deriving.Mirror
 
 final class AppliedViaBuilder[Source, Dest, Func, ArgSelector <: FunctionArguments] private (

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/builder/DefinitionBuilder.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/builder/DefinitionBuilder.scala
@@ -4,7 +4,6 @@ import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.fallible.{ FallibleTransformer, Mode }
 import io.github.arainko.ducktape.internal.macros.*
 
-import scala.compiletime.*
 import scala.deriving.Mirror
 
 final class DefinitionBuilder[Source, Dest] {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/fallibleSyntax.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/fallibleSyntax.scala
@@ -1,12 +1,9 @@
 package io.github.arainko.ducktape
 
-import io.github.arainko.ducktape.builder.*
 import io.github.arainko.ducktape.fallible.FallibleTransformer
 import io.github.arainko.ducktape.function.*
 import io.github.arainko.ducktape.internal.macros.{ Errors, Transformations }
 
-import scala.annotation.implicitNotFound
-import scala.compiletime.*
 import scala.deriving.Mirror
 
 extension [F[+x], Source](value: Source)(using F: Transformer.Mode[F]) {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/function/FunctionArguments.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/function/FunctionArguments.scala
@@ -1,8 +1,5 @@
 package io.github.arainko.ducktape.function
 
-import scala.annotation.implicitNotFound
-import scala.util.NotGiven
-
 sealed trait FunctionArguments extends Selectable {
   def selectDynamic(value: String): Nothing
 }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/AccumulatingProductTransformations.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/AccumulatingProductTransformations.scala
@@ -1,15 +1,11 @@
 package io.github.arainko.ducktape.internal.macros
 
 import io.github.arainko.ducktape.fallible.{ FallibleTransformer, Mode }
-import io.github.arainko.ducktape.function.FunctionMirror
 import io.github.arainko.ducktape.internal.modules.*
 import io.github.arainko.ducktape.internal.util.NonEmptyList
 import io.github.arainko.ducktape.{ BuilderConfig, FallibleBuilderConfig, Transformer }
 
-import scala.annotation.tailrec
-import scala.deriving.Mirror
 import scala.quoted.*
-import scala.util.chaining.*
 
 private[ducktape] object AccumulatingProductTransformations {
   export fallibleTransformations.{ transform, transformConfigured, via, viaConfigured }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/DerivedTransformers.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/DerivedTransformers.scala
@@ -2,8 +2,6 @@ package io.github.arainko.ducktape.internal.macros
 
 import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.fallible.{ FallibleTransformer, Mode }
-import io.github.arainko.ducktape.internal.macros.{ CoproductTransformations, ProductTransformations }
-import io.github.arainko.ducktape.internal.modules.*
 
 import scala.deriving.*
 import scala.quoted.*

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/FailFastProductTransformations.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/FailFastProductTransformations.scala
@@ -6,7 +6,6 @@ import io.github.arainko.ducktape.internal.modules.Field.{ Unwrapped, Wrapped }
 import io.github.arainko.ducktape.internal.modules.*
 
 import scala.annotation.*
-import scala.deriving.Mirror
 import scala.quoted.*
 import scala.util.chaining.*
 

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/FunctionMacros.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/FunctionMacros.scala
@@ -3,12 +3,14 @@ package io.github.arainko.ducktape.internal.macros
 import io.github.arainko.ducktape.function.*
 import io.github.arainko.ducktape.internal.modules.*
 
+import scala.annotation.nowarn
 import scala.quoted.*
 
 // Ideally should live in `modules` but due to problems with ProductTransformations and LiftTransformation
 // is kept here for consistency
 private[ducktape] object FunctionMacros {
 
+  @nowarn("msg=unused local definition")
   def deriveMirror[Func: Type](using Quotes): Expr[FunctionMirror[Func]] = {
     import quotes.reflect.*
 
@@ -39,7 +41,7 @@ private[ducktape] object FunctionMacros {
 
     function.asTerm match {
       case func @ FunctionLambda(valDefs, _) =>
-        refine(TypeRepr.of[FunctionArguments], valDefs).asType match {
+        refine(valDefs).asType match {
           case '[IsFuncArgs[args]] => '{ $initial.asInstanceOf[F[args]] }
         }
 
@@ -47,7 +49,7 @@ private[ducktape] object FunctionMacros {
     }
   }
 
-  private def refine(using Quotes)(tpe: quotes.reflect.TypeRepr, valDefs: List[quotes.reflect.ValDef]) = {
+  private def refine(using Quotes)(valDefs: List[quotes.reflect.ValDef]) = {
     import quotes.reflect.*
 
     valDefs.foldLeft(TypeRepr.of[FunctionArguments])((tpe, valDef) => Refinement(tpe, valDef.name, valDef.tpt.tpe))

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/Functions.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/Functions.scala
@@ -1,7 +1,6 @@
 package io.github.arainko.ducktape.internal.macros
 
 import io.github.arainko.ducktape.function.*
-import io.github.arainko.ducktape.internal.macros.FunctionMacros
 
 private[ducktape] object Functions {
   transparent inline def deriveMirror[Func]: FunctionMirror[Func] = ${ FunctionMacros.deriveMirror[Func] }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformations.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/ProductTransformations.scala
@@ -2,7 +2,6 @@ package io.github.arainko.ducktape.internal.macros
 
 import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.function.*
-import io.github.arainko.ducktape.internal.macros.LiftTransformation
 import io.github.arainko.ducktape.internal.modules.MaterializedConfiguration.*
 import io.github.arainko.ducktape.internal.modules.*
 

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/Transformations.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/macros/Transformations.scala
@@ -3,8 +3,6 @@ package io.github.arainko.ducktape.internal.macros
 import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.fallible.Mode
 import io.github.arainko.ducktape.function.*
-import io.github.arainko.ducktape.internal.macros.{ CoproductTransformations, LiftTransformation }
-import io.github.arainko.ducktape.internal.modules.*
 
 import scala.deriving.Mirror
 import scala.quoted.*

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Failure.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Failure.scala
@@ -1,7 +1,5 @@
 package io.github.arainko.ducktape.internal.modules
 
-import io.github.arainko.ducktape.Transformer
-
 import scala.quoted.*
 
 private[ducktape] sealed trait Failure {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedConfiguration.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedConfiguration.scala
@@ -236,18 +236,15 @@ private[ducktape] object MaterializedConfiguration {
   )(
     extractor: Seq[Expr[Config]] => Seq[MaterializedConfig],
     discriminator: MaterializedConfig => String
-  )(using Quotes) = {
-    import quotes.reflect.*
-
+  )(using Quotes) =
     extractor(Varargs.unapply(config).getOrElse(Failure.emit(Failure.UnsupportedConfig(config, configType))))
       .groupBy(discriminator)
-      .map { (name, configs) =>
+      .map { (_, configs) =>
         if (configs.sizeIs > 1) configs.foreach(cfg => Warning.emit(Warning.ConfiguredRepeatedly(cfg, configType)))
 
         configs.last // keep the last applied field config only
       }
       .toList
-  }
 
   private def accessField(using Quotes)(value: quotes.reflect.Term, field: Field) = {
     import quotes.reflect.*

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Suggesion.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Suggesion.scala
@@ -1,7 +1,5 @@
 package io.github.arainko.ducktape.internal.modules
 
-import io.github.arainko.ducktape.internal.modules.Fields
-
 private[ducktape] opaque type Suggestion = String
 
 private[ducktape] object Suggestion {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/ZippedProduct.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/ZippedProduct.scala
@@ -1,12 +1,9 @@
 package io.github.arainko.ducktape.internal.modules
 
-import io.github.arainko.ducktape.Transformer
 import io.github.arainko.ducktape.fallible.Mode
-import io.github.arainko.ducktape.internal.macros.*
 import io.github.arainko.ducktape.internal.modules.Field.Unwrapped
 import io.github.arainko.ducktape.internal.util.*
 
-import scala.annotation.tailrec
 import scala.quoted.*
 
 object ZippedProduct {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/util/NonEmptyList.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/util/NonEmptyList.scala
@@ -1,7 +1,5 @@
 package io.github.arainko.ducktape.internal.util
 
-import scala.NonEmptyTuple
-
 private[ducktape] opaque type NonEmptyList[+A] = ::[A]
 
 private[ducktape] object NonEmptyList {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
@@ -3,9 +3,7 @@ package io.github.arainko.ducktape
 import io.github.arainko.ducktape.builder.*
 import io.github.arainko.ducktape.function.*
 import io.github.arainko.ducktape.internal.macros.*
-import io.github.arainko.ducktape.internal.modules.*
 
-import scala.annotation.experimental
 import scala.deriving.Mirror
 
 extension [Source](value: Source) {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/DerivedInstanceSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/DerivedInstanceSuite.scala
@@ -2,9 +2,7 @@ package io.github.arainko.ducktape.fallible.accumulating
 
 import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.fallible.model.*
-import io.github.arainko.ducktape.fallible.model.basic.{ CreateConference, CreateTalk, UpdateTalk }
-
-import java.time.LocalDate
+import io.github.arainko.ducktape.fallible.model.basic.CreateTalk
 
 class DerivedInstanceSuite extends DucktapeSuite {
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/NonDerivedInstanceSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/NonDerivedInstanceSuite.scala
@@ -4,8 +4,6 @@ import io.github.arainko.ducktape.fallible.Mode.Accumulating
 import io.github.arainko.ducktape.fallible.model.*
 import io.github.arainko.ducktape.{ DucktapeSuite, Transformer }
 
-import scala.collection.Factory
-
 class NonDerivedInstanceSuite extends DucktapeSuite {
 
   private given Accumulating[[A] =>> Either[List[Predef.String], A]] =

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/failfast/DerivedInstanceSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/failfast/DerivedInstanceSuite.scala
@@ -2,9 +2,7 @@ package io.github.arainko.ducktape.fallible.failfast
 
 import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.fallible.model.*
-import io.github.arainko.ducktape.fallible.model.basic.{ CreateConference, CreateTalk, UpdateTalk }
-
-import java.time.LocalDate
+import io.github.arainko.ducktape.fallible.model.basic.CreateTalk
 
 class DerivedInstanceSuite extends DucktapeSuite {
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/model/Conference.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/model/Conference.scala
@@ -1,6 +1,5 @@
 package io.github.arainko.ducktape.fallible.model
 
-import java.time.LocalDate
 import java.util.UUID
 
 final case class Conference(id: Conference.Id, info: Conference.Info, talks: Vector[Talk])

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/model/NewtypeValidated.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/model/NewtypeValidated.scala
@@ -1,6 +1,5 @@
 package io.github.arainko.ducktape.fallible.model
 
-import io.github.arainko.ducktape.Transformer
 import io.github.arainko.ducktape.fallible.FallibleTransformer
 
 def AlwaysValid[A]: A => Either[String, Unit] = _ => Right(())

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/model/Talk.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/model/Talk.scala
@@ -1,7 +1,5 @@
 package io.github.arainko.ducktape.fallible.model
 
-import java.util.UUID
-
 final case class Talk(name: Talk.Name, elevatorPitch: Talk.ElevatorPitch, presenter: Presenter)
 
 object Talk {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue38Spec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue38Spec.scala
@@ -1,7 +1,8 @@
 package io.github.arainko.ducktape.issues
 
 import io.github.arainko.ducktape.*
-import io.github.arainko.ducktape.internal.macros.*
+
+import scala.annotation.nowarn
 
 // https://github.com/arainko/ducktape/issues/38
 class Issue38Spec extends DucktapeSuite {
@@ -28,6 +29,7 @@ class Issue38Spec extends DucktapeSuite {
   }
 
   test("Field.default fails when a field doesn't have a default value") {
+    @nowarn("msg=unused local definition")
     val testClass = TestClass("str", 1)
 
     assertFailsToCompileWith {
@@ -42,6 +44,7 @@ class Issue38Spec extends DucktapeSuite {
   }
 
   test("Field.default fails when the default doesn't match the expected type") {
+    @nowarn("msg=unused local definition")
     val testClass = TestClass("str", 1)
 
     assertFailsToCompileWith {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/macros/MakeTransformerSpec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/macros/MakeTransformerSpec.scala
@@ -1,12 +1,8 @@
 package io.github.arainko.ducktape.macros
 
 import io.github.arainko.ducktape.*
-import io.github.arainko.ducktape.internal.macros.*
-import io.github.arainko.ducktape.macros.MakeTransformerChecker
 import io.github.arainko.ducktape.model.*
 import munit.*
-
-import scala.quoted.*
 
 class MakeTransformerSpec extends DucktapeSuite {
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/macros/TransformerLambdaSpec.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/macros/TransformerLambdaSpec.scala
@@ -1,7 +1,6 @@
 package io.github.arainko.ducktape.macros
 
 import io.github.arainko.ducktape.*
-import io.github.arainko.ducktape.macros.TransformerLambdaChecker
 import io.github.arainko.ducktape.model.*
 
 class TransformerLambdaSpec extends DucktapeSuite {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/builder/AppliedBuilderSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/builder/AppliedBuilderSuite.scala
@@ -1,10 +1,8 @@
 package io.github.arainko.ducktape.total.builder
 
 import io.github.arainko.ducktape.*
-import io.github.arainko.ducktape.internal.macros.DebugMacros
 
 import scala.annotation.nowarn
-import scala.deriving.Mirror
 
 class AppliedBuilderSuite extends DucktapeSuite {
   import AppliedBuilderSuite.*
@@ -130,7 +128,10 @@ class AppliedBuilderSuite extends DucktapeSuite {
   }
 
   test("Field.allMatching reports a compiletime failure when none of the fields match") {
+    @nowarn("msg=unused local definition")
     final case class Source(int: Int, str: String, list: List[String])
+
+    @nowarn("msg=unused local definition")
     final case class FieldSource(int: Long, str: CharSequence, list: Vector[String])
 
     assertFailsToCompileWith {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/builder/AppliedViaBuilderSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/builder/AppliedViaBuilderSuite.scala
@@ -3,8 +3,9 @@ package io.github.arainko.ducktape.total.builder
 import io.github.arainko.ducktape.*
 import io.github.arainko.ducktape.builder.AppliedViaBuilder
 import io.github.arainko.ducktape.function.FunctionArguments
-import io.github.arainko.ducktape.internal.macros.DebugMacros
 import io.github.arainko.ducktape.total.builder.AppliedViaBuilderSuite.*
+
+import scala.annotation.nowarn
 
 class AppliedViaBuilderSuite extends DucktapeSuite {
   private val testClass = TestClass("str", 1)
@@ -49,6 +50,7 @@ class AppliedViaBuilderSuite extends DucktapeSuite {
   }
 
   test("When an Arg is configured multiple times a warning is emitted") {
+    @nowarn("msg=unused local definition")
     def method(str: String, int: Int, additionalArg: String) = TestClassWithAdditionalString(int, str, additionalArg)
 
     assertFailsToCompileWith {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
@@ -7,7 +7,6 @@ import io.github.arainko.ducktape.model.*
 import munit.FunSuite
 
 import scala.compiletime.testing.*
-import scala.deriving.Mirror
 
 object DerivedTransformerSuite {
 // If these are declared inside their tests the compiler crashes 🤔

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/ViaSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/ViaSuite.scala
@@ -1,7 +1,6 @@
 package io.github.arainko.ducktape.total.derivation
 
 import io.github.arainko.ducktape.*
-import io.github.arainko.ducktape.internal.macros.DebugMacros
 import munit.FunSuite
 
 import scala.compiletime.testing.*


### PR DESCRIPTION
* `fallibleVia` and other fallible `via` variants now beta-reduce their function application to a simple method call which also fixes a problem with owners for those methods (dotty 3.3.0-RC5 was nice enough to yell at me for that)
* test drive of "-Wunused:all" for the whole project (there were A LOT of unused imports) and a single false-positive - pretty nice