### PR TITLE
[Issue#54] Move contents of `fallibleSyntax.scala` to `syntax.scala`

### DIFF
--- a/ducktape/src/main/scala/io/github/arainko/ducktape/fallibleSyntax.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/fallibleSyntax.scala
@@ -1,26 +1,7 @@
 package io.github.arainko.ducktape
 
-import io.github.arainko.ducktape.fallible.FallibleTransformer
-import io.github.arainko.ducktape.function.*
-import io.github.arainko.ducktape.internal.macros.{ Errors, Transformations }
-
-import scala.deriving.Mirror
-
-extension [F[+x], Source](value: Source)(using F: Transformer.Mode[F]) {
-
-  inline def fallibleTo[Dest](using transformer: FallibleTransformer[F, Source, Dest]): F[Dest] =
-    transformer.transform(value)
-
-  inline def fallibleVia[Func](inline function: Func)(using
-    Func: FunctionMirror[Func]
-  )(using Source: Mirror.ProductOf[Source]): F[Func.Return] =
-    inline F match {
-      case given fallible.Mode.FailFast[F] =>
-        Transformations.failFastVia[F, Source, Func](function)(value)
-      case given fallible.Mode.Accumulating[F] =>
-        Transformations.accumulatingVia[F, Source, Func](function)(value)
-      case other =>
-        Errors.cannotDetermineTransformationMode
-    }
-
-}
+// Workarounds https://github.com/arainko/ducktape/issues/54 by moving the contents to `syntax.scala`
+// The names here are weird due to how dotty mangles toplevel definitions and need to stay for binary-compat
+// TODO: Remove this in 0.2.0
+private[ducktape] final class fallibleSyntax$package
+private[ducktape] object fallibleSyntax$package

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/syntax.scala
@@ -19,3 +19,22 @@ extension [Source](value: Source) {
     Source: Mirror.ProductOf[Source]
   ): Func.Return = Transformations.via(value, function)
 }
+
+extension [F[+x], Source](value: Source)(using F: Transformer.Mode[F]) {
+
+  inline def fallibleTo[Dest](using transformer: Transformer.Fallible[F, Source, Dest]): F[Dest] =
+    transformer.transform(value)
+
+  inline def fallibleVia[Func](inline function: Func)(using
+    Func: FunctionMirror[Func]
+  )(using Source: Mirror.ProductOf[Source]): F[Func.Return] =
+    inline F match {
+      case given fallible.Mode.FailFast[F] =>
+        Transformations.failFastVia[F, Source, Func](function)(value)
+      case given fallible.Mode.Accumulating[F] =>
+        Transformations.accumulatingVia[F, Source, Func](function)(value)
+      case other =>
+        Errors.cannotDetermineTransformationMode
+    }
+
+}


### PR DESCRIPTION
This is a workaround for #54 (which I'm pretty sure is a dotty issue but it's proven to be really hard to write a proper minimization for)