### PR TITLE
[issue#61] More advanced coproduct transformations

### DIFF
--- a/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
@@ -5,6 +5,7 @@ import io.github.arainko.ducktape.internal.macros.*
 
 import scala.collection.Factory
 import scala.deriving.Mirror
+import scala.annotation.implicitNotFound
 
 @FunctionalInterface
 trait Transformer[Source, Dest] {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/Transformer.scala
@@ -3,9 +3,9 @@ package io.github.arainko.ducktape
 import io.github.arainko.ducktape.builder.*
 import io.github.arainko.ducktape.internal.macros.*
 
+import scala.annotation.implicitNotFound
 import scala.collection.Factory
 import scala.deriving.Mirror
-import scala.annotation.implicitNotFound
 
 @FunctionalInterface
 trait Transformer[Source, Dest] {

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Case.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Case.scala
@@ -1,12 +1,26 @@
 package io.github.arainko.ducktape.internal.modules
 
 import scala.quoted.*
+import io.github.arainko.ducktape.Transformer
 
 private[ducktape] final case class Case(
   val name: String,
   val tpe: Type[?],
   val ordinal: Int
 ) {
+
+  def transformerTo(that: Case)(using Quotes): Option[Expr[Transformer[?, ?]]] = {
+    import quotes.reflect.*
+
+    (tpe -> that.tpe) match {
+      case '[src] -> '[dest] =>
+        Implicits.search(TypeRepr.of[Transformer[src, dest]]) match {
+          case success: ImplicitSearchSuccess => Some(success.tree.asExprOf[Transformer[src, dest]])
+          case err: ImplicitSearchFailure     => None
+        }
+    }
+  }
+
   def materializeSingleton(using Quotes): Option[quotes.reflect.Term] = {
     import quotes.reflect.*
 

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Case.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Case.scala
@@ -21,13 +21,13 @@ private[ducktape] final case class Case(
     }
   }
 
-  def materializeSingleton(using Quotes): Option[quotes.reflect.Term] = {
+  def materializeSingleton(using Quotes): Option[Expr[Any]] = {
     import quotes.reflect.*
 
     val typeRepr = TypeRepr.of(using tpe)
 
     Option.when(typeRepr.isSingleton) {
-      typeRepr match { case TermRef(a, b) => Ident(TermRef(a, b)) }
+      typeRepr match { case TermRef(a, b) => Ident(TermRef(a, b)).asExpr }
     }
   }
 }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Case.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Case.scala
@@ -1,7 +1,8 @@
 package io.github.arainko.ducktape.internal.modules
 
-import scala.quoted.*
 import io.github.arainko.ducktape.Transformer
+
+import scala.quoted.*
 
 private[ducktape] final case class Case(
   val name: String,

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Cases.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Cases.scala
@@ -11,7 +11,7 @@ private[ducktape] sealed trait Cases {
   val byName: Map[String, Case] = value.map(c => c.name -> c).toMap
 }
 
-object Cases {
+private[ducktape] object Cases {
   def source(using sourceCases: Cases.Source): Cases.Source = sourceCases
   def dest(using destCases: Cases.Dest): Cases.Dest = destCases
 
@@ -25,12 +25,11 @@ object Cases {
     def apply(cases: List[Case]): CasesSubtype
 
     final def fromMirror[A: Type](mirror: Expr[Mirror.SumOf[A]])(using Quotes): CasesSubtype = {
-      val materializedMirror = MaterializedMirror.createOrAbort(mirror)
+      val materializedMirror = MaterializedMirror.create(mirror)
 
       val cases = materializedMirror.mirroredElemLabels
         .zip(materializedMirror.mirroredElemTypes)
-        .zipWithIndex
-        .map { case name -> tpe -> ordinal => Case(name, tpe.asType, ordinal) }
+        .map(Case.apply)
 
       apply(cases)
     }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Constructor.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Constructor.scala
@@ -12,6 +12,9 @@ private[ducktape] object Constructor {
         case notApplied                       => (tpe, tpe.typeSymbol.primaryConstructor, Nil)
       }
 
+    //workaround for invoking constructors of singleton which in turn actually create new instances of singletons!
+    if (tpe.typeSymbol.flags.is(Flags.Module)) report.errorAndAbort("Cannot invoke constructor of a singleton")
+
     New(Inferred(repr))
       .select(constructor)
       .appliedToTypes(tpeArgs)

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Constructor.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Constructor.scala
@@ -12,7 +12,7 @@ private[ducktape] object Constructor {
         case notApplied                       => (tpe, tpe.typeSymbol.primaryConstructor, Nil)
       }
 
-    //workaround for invoking constructors of singleton which in turn actually create new instances of singletons!
+    // workaround for invoking constructors of singleton which in turn actually create new instances of singletons!
     if (tpe.typeSymbol.flags.is(Flags.Module)) report.errorAndAbort("Cannot invoke constructor of a singleton")
 
     New(Inferred(repr))

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Failure.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Failure.scala
@@ -142,13 +142,14 @@ private[ducktape] object Failure {
     override final def render(using Quotes): String = s"No child named '$childName' found in ${destinationType.show}"
   }
 
-  final case class CannotMaterializeSingleton(tpe: Type[?]) extends Failure {
-    private def suggestions(using Quotes) = Suggestion.all(s"${tpe.show} is not a singleton type")
-
+  final case class CannotTransformCoproductCase(source: Type[?], dest: Type[?], implicitSearchExplanation: String) extends Failure {
     override final def render(using Quotes): String =
       s"""
-        |Cannot materialize singleton for ${tpe.show}.
-        |Possible causes: ${Suggestion.renderAll(suggestions)}
+        |Neither an instance of Transformer[${source.fullName}, ${dest.fullName}] was found nor are '${source.show}' '${dest.show}' 
+        |singletons with the same name.
+        |
+        |Compiler supplied explanation for the failed Transformer derivation (may or may not be helpful):
+        |$implicitSearchExplanation
         """.stripMargin
   }
 

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Failure.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Failure.scala
@@ -142,7 +142,8 @@ private[ducktape] object Failure {
     override final def render(using Quotes): String = s"No child named '$childName' found in ${destinationType.show}"
   }
 
-  final case class CannotTransformCoproductCase(source: Type[?], dest: Type[?], implicitSearchExplanation: String) extends Failure {
+  final case class CannotTransformCoproductCase(source: Type[?], dest: Type[?], implicitSearchExplanation: String)
+      extends Failure {
     override final def render(using Quotes): String =
       s"""
         |Neither an instance of Transformer[${source.fullName}, ${dest.fullName}] was found nor are '${source.show}' '${dest.show}' 

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Field.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Field.scala
@@ -5,7 +5,10 @@ import io.github.arainko.ducktape.fallible.FallibleTransformer
 
 import scala.quoted.*
 
-private[ducktape] final class Field(val name: String, val tpe: Type[?], val default: Option[Expr[Any]]) {
+private[ducktape] final class Field(val name: String, val tpe: Type[?], defaultValue: => Option[Expr[Any]]) {
+
+  lazy val default: Option[Expr[Any]] = defaultValue
+
   def transformerTo(that: Field)(using Quotes): Expr[Transformer[?, ?]] = {
     import quotes.reflect.*
 

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Fields.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/Fields.scala
@@ -30,7 +30,7 @@ private[ducktape] object Fields {
     final def fromMirror[A: Type](mirror: Expr[Mirror.ProductOf[A]])(using Quotes): FieldsSubtype = {
       val materializedMirror = MaterializedMirror.createOrAbort(mirror)
 
-      val defaults = defaultParams[A]
+      lazy val defaults = defaultParams[A]
       val fields = materializedMirror.mirroredElemLabels
         .zip(materializedMirror.mirroredElemTypes)
         .map((name, tpe) => Field(name, tpe.asType, defaults.get(name)))

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedMirror.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedMirror.scala
@@ -4,15 +4,14 @@ import scala.annotation.tailrec
 import scala.deriving.Mirror
 import scala.quoted.*
 
-private[ducktape] final class MaterializedMirror[Q <: Quotes & Singleton] private (using val quotes: Q)(
-  val mirroredType: quotes.reflect.TypeRepr,
-  val mirroredElemTypes: List[quotes.reflect.TypeRepr],
+private[ducktape] final class MaterializedMirror(
+  val mirroredElemTypes: List[Type[?]],
   val mirroredElemLabels: List[String]
 )
 
 private[ducktape] object MaterializedMirror {
 
-  def createOrAbort[A: Type](mirror: Expr[Mirror.Of[A]])(using Quotes): MaterializedMirror[quotes.type] =
+  def create[A: Type](mirror: Expr[Mirror.Of[A]])(using Quotes): MaterializedMirror =
     mirror match {
       case '{
             $m: Mirror.Of[A] {
@@ -22,19 +21,21 @@ private[ducktape] object MaterializedMirror {
           } =>
         import quotes.reflect.*
         val elemTypes = tupleTypeElements(TypeRepr.of[types])
-        val labels = tupleTypeElements(TypeRepr.of[labels]).map { case ConstantType(StringConstant(l)) => l }
-        MaterializedMirror(TypeRepr.of[A], elemTypes, labels)
+        val labels = tupleTypeElements(TypeRepr.of[labels]).map { case '[IsString[tpe]] => Type.valueOfConstant[tpe].getOrElse(report.errorAndAbort("Couldn't extract constact value")) }
+        MaterializedMirror(elemTypes, labels)
     }
 
-  private def tupleTypeElements(using Quotes)(tp: quotes.reflect.TypeRepr): List[quotes.reflect.TypeRepr] = {
+  private def tupleTypeElements(using Quotes)(tp: quotes.reflect.TypeRepr): List[Type[?]] = {
     import quotes.reflect.*
 
-    @tailrec def loop(curr: TypeRepr, acc: List[TypeRepr]): List[TypeRepr] =
+    @tailrec def loop(curr: TypeRepr, acc: List[Type[?]]): List[Type[?]] =
       curr match {
-        case AppliedType(pairTpe, head :: tail :: Nil) => loop(tail, head :: acc)
+        case AppliedType(pairTpe, head :: tail :: Nil) => loop(tail, head.asType :: acc)
         case _                                         => acc
       }
     loop(tp, Nil).reverse
   }
+
+  private type IsString[A <: String] = A
 
 }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedMirror.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedMirror.scala
@@ -21,7 +21,9 @@ private[ducktape] object MaterializedMirror {
           } =>
         import quotes.reflect.*
         val elemTypes = tupleTypeElements(TypeRepr.of[types])
-        val labels = tupleTypeElements(TypeRepr.of[labels]).map { case '[IsString[tpe]] => Type.valueOfConstant[tpe].getOrElse(report.errorAndAbort("Couldn't extract constact value")) }
+        val labels = tupleTypeElements(TypeRepr.of[labels]).map {
+          case '[IsString[tpe]] => Type.valueOfConstant[tpe].getOrElse(report.errorAndAbort("Couldn't extract constact value"))
+        }
         MaterializedMirror(elemTypes, labels)
     }
 

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedMirror.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/MaterializedMirror.scala
@@ -6,65 +6,35 @@ import scala.quoted.*
 
 private[ducktape] final class MaterializedMirror[Q <: Quotes & Singleton] private (using val quotes: Q)(
   val mirroredType: quotes.reflect.TypeRepr,
-  val mirroredMonoType: quotes.reflect.TypeRepr,
   val mirroredElemTypes: List[quotes.reflect.TypeRepr],
-  val mirroredLabel: String,
   val mirroredElemLabels: List[String]
 )
 
-// Lifted from shapeless 3:
-// https://github.com/typelevel/shapeless-3/blob/main/modules/deriving/src/main/scala/shapeless3/deriving/internals/reflectionutils.scala
 private[ducktape] object MaterializedMirror {
 
   def createOrAbort[A: Type](mirror: Expr[Mirror.Of[A]])(using Quotes): MaterializedMirror[quotes.type] =
-    create(mirror).fold(memberName => Failure.emit(Failure.MirrorMaterialization(summon, memberName)), identity)
-
-  private def create(mirror: Expr[Mirror])(using Quotes): Either[String, MaterializedMirror[quotes.type]] = {
-    import quotes.reflect.*
-
-    val mirrorTpe = mirror.asTerm.tpe.widen
-    for {
-      mirroredType <- findMemberType(mirrorTpe, "MirroredType")
-      mirroredMonoType <- findMemberType(mirrorTpe, "MirroredMonoType")
-      mirroredElemTypes <- findMemberType(mirrorTpe, "MirroredElemTypes")
-      mirroredLabel <- findMemberType(mirrorTpe, "MirroredLabel")
-      mirroredElemLabels <- findMemberType(mirrorTpe, "MirroredElemLabels")
-    } yield {
-      val elemTypes = tupleTypeElements(mirroredElemTypes)
-      val ConstantType(StringConstant(label)) = mirroredLabel: @unchecked
-      val elemLabels = tupleTypeElements(mirroredElemLabels).map { case ConstantType(StringConstant(l)) => l }
-      MaterializedMirror(mirroredType, mirroredMonoType, elemTypes, label, elemLabels)
+    mirror match {
+      case '{
+            $m: Mirror.Of[A] {
+              type MirroredElemTypes = types
+              type MirroredElemLabels = labels
+            }
+          } =>
+        import quotes.reflect.*
+        val elemTypes = tupleTypeElements(TypeRepr.of[types])
+        val labels = tupleTypeElements(TypeRepr.of[labels]).map { case ConstantType(StringConstant(l)) => l }
+        MaterializedMirror(TypeRepr.of[A], elemTypes, labels)
     }
-  }
 
   private def tupleTypeElements(using Quotes)(tp: quotes.reflect.TypeRepr): List[quotes.reflect.TypeRepr] = {
     import quotes.reflect.*
 
-    @tailrec def loop(tp: TypeRepr, acc: List[TypeRepr]): List[TypeRepr] = tp match {
-      case AppliedType(pairTpe, List(hd: TypeRepr, tl: TypeRepr)) => loop(tl, hd :: acc)
-      case _                                                      => acc
-    }
+    @tailrec def loop(curr: TypeRepr, acc: List[TypeRepr]): List[TypeRepr] =
+      curr match {
+        case AppliedType(pairTpe, head :: tail :: Nil) => loop(tail, head :: acc)
+        case _                                         => acc
+      }
     loop(tp, Nil).reverse
-  }
-
-  private def low(using Quotes)(tp: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr = {
-    import quotes.reflect.*
-
-    tp match {
-      case tp: TypeBounds => tp.low
-      case tp             => tp
-    }
-  }
-
-  private def findMemberType(using Quotes)(tp: quotes.reflect.TypeRepr, name: String): Either[String, quotes.reflect.TypeRepr] = {
-    import quotes.reflect.*
-
-    tp match {
-      case Refinement(_, `name`, tp) => Right(low(tp))
-      case Refinement(parent, _, _)  => findMemberType(parent, name)
-      case AndType(left, right)      => findMemberType(left, name).orElse(findMemberType(right, name))
-      case _                         => Left(name)
-    }
   }
 
 }

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/builder/AppliedBuilderSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/builder/AppliedBuilderSuite.scala
@@ -208,6 +208,69 @@ class AppliedBuilderSuite extends DucktapeSuite {
     assertEquals(actual(NotEnumMoreCases.Case4(2)), expectedForOther)
   }
 
+  test("sums of products can be configured") {
+    enum Sum1 {
+      case Leaf1(int: Int, str: String)
+      case Leaf2(int1: Int, str2: String, list: List[Int])
+      case Leaf3(int3: Int, str3: String, opt: Option[Int])
+      case Singleton
+    }
+
+    enum Sum2 {
+      case Leaf1(int: Int, str: String)
+      case Leaf3(int3: Int, str3: String, opt: Option[Int])
+      case Singleton2
+    }
+
+    val transformer =
+      Transformer
+        .define[Sum1, Sum2]
+        .build(
+          Case.computed[Sum1.Leaf2](leaf2 => Sum2.Leaf1(leaf2.int1, leaf2.str2)),
+          Case.const[Sum1.Singleton.type](Sum2.Singleton2)
+        )
+
+    val expectedMappings =
+      Map(
+        Sum1.Leaf1(1, "str") -> Sum2.Leaf1(1, "str"),
+        Sum1.Leaf2(2, "str2", List(1, 2, 3)) -> Sum2.Leaf1(2, "str2"),
+        Sum1.Leaf3(3, "str3", Some(1)) -> Sum2.Leaf3(3, "str3", Some(1)),
+        Sum1.Singleton -> Sum2.Singleton2
+      )
+
+    expectedMappings.foreach { (sum1, expected) =>
+      val actual = sum1
+        .into[Sum2]
+        .transform(
+          Case.computed[Sum1.Leaf2](leaf2 => Sum2.Leaf1(leaf2.int1, leaf2.str2)),
+          Case.const[Sum1.Singleton.type](Sum2.Singleton2)
+        )
+      assertEquals(actual, expected)
+    }
+  }
+
+  test("sums with type parameters can be confgured") {
+    enum Sum1[A] {
+      case Leaf1(int: Int, a: A)
+    }
+
+    enum Sum2[A] {
+      case Leaf2(int: Int, a: Option[A])
+    }
+
+    val leaf1 = Sum1.Leaf1(1, 1)
+
+    val expected = Sum2.Leaf2(1, Some("1"))
+
+    val actual = leaf1
+      .into[Sum2[String]]
+      .transform(
+        Case.computed[Sum1.Leaf1[Int]](a => Sum2.Leaf2(a.int, Some(a.a.toString())))
+      )
+
+    assertEquals(actual, expected)
+  }
+
   test("When a Case is configured multiple times a warning is emitted") {
 
     assertFailsToCompileWith {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
@@ -274,21 +274,17 @@ class DerivedTransformerSuite extends DucktapeSuite {
 
   test("test") {
 
-    object Costam1 {
-      case object Cos
-    }
-
-    object Costam2 {
-      case object Cos
-    }
-
     // Transformer.Debug.showCode {
 
     Transformer.betweenCoproducts[AdtDerivationTest1, AdtDerivationTest2]
 
-    Transformer.Debug.showCode {
-      summon[Transformer[Costam1.Cos.type, Costam2.Cos.type]]
-    }    
+
+
+    // }
+    // Transformer.Debug.showCode {
+      // summon[Transformer[Costam1.Cos.type, Costam2.Cos.type]]
+    // }    
+
 
     // }
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
@@ -274,10 +274,23 @@ class DerivedTransformerSuite extends DucktapeSuite {
 
   test("test") {
 
-    Transformer.Debug.showCode {
+    object Costam1 {
+      case object Cos
+    }
+
+    object Costam2 {
+      case object Cos
+    }
+
+    // Transformer.Debug.showCode {
 
     Transformer.betweenCoproducts[AdtDerivationTest1, AdtDerivationTest2]
-    }
+
+    Transformer.Debug.showCode {
+      summon[Transformer[Costam1.Cos.type, Costam2.Cos.type]]
+    }    
+
+    // }
 
   }
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
@@ -36,6 +36,18 @@ object DerivedTransformerSuite {
   }
 
   final case class Wrapped[A](value: A) extends AnyVal
+
+  enum AdtDerivationTest1 {
+    case Case1
+    case Case2
+    case Case3(str: String, int: Int)
+  }
+
+  enum AdtDerivationTest2 {
+    case Case1
+    case Case2
+    case Case3(str: String, int: Int)
+  }
 }
 
 class DerivedTransformerSuite extends DucktapeSuite {
@@ -258,6 +270,15 @@ class DerivedTransformerSuite extends DucktapeSuite {
     val actual = transformer.transform(LessCases.Case3)
 
     assertEquals(actual, expected)
+  }
+
+  test("test") {
+
+    Transformer.Debug.showCode {
+
+    Transformer.betweenCoproducts[AdtDerivationTest1, AdtDerivationTest2]
+    }
+
   }
 
   test("derivation fails when going from a sum with more cases to a sum with less cases") {

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/total/derivation/DerivedTransformerSuite.scala
@@ -36,18 +36,6 @@ object DerivedTransformerSuite {
   }
 
   final case class Wrapped[A](value: A) extends AnyVal
-
-  enum AdtDerivationTest1 {
-    case Case1
-    case Case2
-    case Case3(str: String, int: Int)
-  }
-
-  enum AdtDerivationTest2 {
-    case Case1
-    case Case2
-    case Case3(str: String, int: Int)
-  }
 }
 
 class DerivedTransformerSuite extends DucktapeSuite {
@@ -272,22 +260,94 @@ class DerivedTransformerSuite extends DucktapeSuite {
     assertEquals(actual, expected)
   }
 
-  test("test") {
+  test("derivation succeeds when going from a sum of cases with the same name as the target sum (enum)") {
 
-    // Transformer.Debug.showCode {
+    enum Sum1 {
+      case Leaf1(int: Int, str: String)
+      case Leaf2(int1: Int, str2: String, list: List[Int])
+      case Leaf3(int3: Int, str3: String, opt: Option[Int], nested: Nested1)
+      case Singleton
+    }
 
-    Transformer.betweenCoproducts[AdtDerivationTest1, AdtDerivationTest2]
+    enum Sum2 {
+      case Leaf1(int: Int | Double, str: CharSequence)
+      case Leaf2(int1: Int | Long, str2: CharSequence, list: Vector[Int | String])
+      case Leaf3(int3: Int, str3: String, opt: Option[Int], nested: Nested2)
+      case Singleton
+    }
 
+    case class Nested1(int: Int)
+    case class Nested2(int: Int)
 
+    val expectedMappings =
+      Map(
+        Sum1.Leaf1(1, "str") -> Sum2.Leaf1(1, "str"),
+        Sum1.Leaf2(2, "str2", List(1, 2, 3)) -> Sum2.Leaf2(2, "str2", Vector(1, 2, 3)),
+        Sum1.Leaf3(3, "str3", None, Nested1(1)) -> Sum2.Leaf3(3, "str3", None, Nested2(1)),
+        Sum1.Singleton -> Sum2.Singleton
+      )
 
-    // }
-    // Transformer.Debug.showCode {
-      // summon[Transformer[Costam1.Cos.type, Costam2.Cos.type]]
-    // }    
+    expectedMappings.foreach((sum1, expected) => assertEquals(sum1.to[Sum2], expected))
+  }
 
+  test("derivation succeeds when going from a sum of cases with the same name as the target sum (sealed trait)") {
+    sealed trait Sum1
 
-    // }
+    object Sum1 {
+      case class Leaf1(int: Int, str: String) extends Sum1
+      case class Leaf2(int1: Int, str2: String, list: List[Int]) extends Sum1
+      case class Leaf3(int3: Int, str3: String, opt: Option[Int]) extends Sum1
+      case object Singleton extends Sum1
+    }
 
+    sealed trait Sum2
+
+    object Sum2 {
+      case class Leaf1(int: Int, str: String) extends Sum2
+      case class Leaf2(int1: Int, str2: String, list: Vector[Int | String]) extends Sum2
+      case class Leaf3(int3: Int, str3: String, opt: Option[Int]) extends Sum2
+      case object Singleton extends Sum2
+    }
+
+    val expectedMappings =
+      Map(
+        Sum1.Leaf1(1, "str") -> Sum2.Leaf1(1, "str"),
+        Sum1.Leaf2(2, "str2", List(1, 2, 3)) -> Sum2.Leaf2(2, "str2", Vector(1, 2, 3)),
+        Sum1.Leaf3(3, "str3", Some(1)) -> Sum2.Leaf3(3, "str3", Some(1)),
+        Sum1.Singleton -> Sum2.Singleton
+      )
+
+    expectedMappings.foreach((sum1, expected) => assertEquals(sum1.to[Sum2], expected))
+  }
+
+  test("derivation succeeds betweens sums with type parameters") {
+    enum Sum1[A] {
+      case Leaf1(int: Int, a: A)
+    }
+
+    enum Sum2[A] {
+      case Leaf1(int: Int, a: Option[A])
+    }
+
+    val leaf1 = Sum1.Leaf1(1, "asd")
+    val expected = Sum2.Leaf1(1, Some("asd"))
+
+    assertEquals(leaf1.to[Sum2[String]], expected)
+  }
+
+  test("derivation fails when a Transformer doesn't exist for a child with the same name") {
+    enum Sum1 {
+      case Leaf1(int: Int, str: String)
+    }
+
+    enum Sum2 {
+      case Leaf1(str1: String)
+    }
+
+    assertFailsToCompileWith("summon[Transformer[Sum1, Sum2]]") {
+      """Neither an instance of Transformer[Sum1.Leaf1, Sum2.Leaf1] was found nor are 'Leaf1' 'Leaf1' 
+singletons with the same name"""
+    }
   }
 
   test("derivation fails when going from a sum with more cases to a sum with less cases") {


### PR DESCRIPTION
Coproducts made of products can now be transformed between each other (given that the names of the children match)

Closes #61 