### PR TITLE
Use correct set of flags for `Symbol.newBind` in `ZippedProduct`

### DIFF
--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/ZippedProduct.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/modules/ZippedProduct.scala
@@ -113,8 +113,8 @@ object ZippedProduct {
         case ('[Tuple2[first, second]], Field.Wrapped(firstField, _) :: Field.Wrapped(secondField, _) :: Nil) =>
           val firstTpe = TypeRepr.of[second]
           val secondTpe = TypeRepr.of[first]
-          val firstBind = Symbol.newBind(Symbol.spliceOwner, firstField.name, Flags.Local, firstTpe)
-          val secondBind = Symbol.newBind(Symbol.spliceOwner, secondField.name, Flags.Local, secondTpe)
+          val firstBind = Symbol.newBind(Symbol.spliceOwner, firstField.name, Flags.Case, firstTpe)
+          val secondBind = Symbol.newBind(Symbol.spliceOwner, secondField.name, Flags.Case, secondTpe)
           val fields =
             List(Field.Unwrapped(secondField, Ref(secondBind).asExpr), Field.Unwrapped(firstField, Ref(firstBind).asExpr))
           val extractor =
@@ -123,14 +123,14 @@ object ZippedProduct {
 
         case ('[tpe], Field.Wrapped(field, _) :: Nil) =>
           val tpe = TypeRepr.of(using field.tpe)
-          val bind = Symbol.newBind(Symbol.spliceOwner, field.name, Flags.Local, tpe)
+          val bind = Symbol.newBind(Symbol.spliceOwner, field.name, Flags.Case, tpe)
           Bind(bind, Wildcard()) -> (Field.Unwrapped(field, Ref(bind).asExpr) :: Nil)
 
         case ('[Tuple2[rest, current]], Field.Wrapped(field, _) :: tail) =>
           val restTpe = TypeRepr.of[rest]
           val currentTpe = TypeRepr.of[current]
           val pairExtractor = Tuple2Extractor(restTpe, currentTpe)
-          val bind = Symbol.newBind(Symbol.spliceOwner, field.name, Flags.Local, currentTpe)
+          val bind = Symbol.newBind(Symbol.spliceOwner, field.name, Flags.Case, currentTpe)
           val (pattern, unzippedFields) = recurse(summon[Type[rest]], tail)
           val extractor = Unapply(pairExtractor, Nil, pattern :: Bind(bind, Wildcard()) :: Nil)
           val fields = Field.Unwrapped(field, Ref(bind).asExpr) :: unzippedFields


### PR DESCRIPTION
Scala 3.3.1 would introduce additional checks under `-Xcheck-macros` flags, one of these are validating correct usage of `Flags` for `Symbol.newBind`. https://github.com/lampepfl/dotty/commit/3c3c0fbb54f6dfd4141ba7be014d092ed2f293be 
 Currently used `Flags.Locals` are incorrect as they should be used for `Symbol.newVal`. `Symbol.newBind` requires subset of `Flags.Case`. The issue was found in the Open Community Build for Scala 3.3.1-RC5 and the logs can be [found here](https://github.com/VirtusLab/community-build3/actions/runs/5830260387/job/15813344883) 

I propose a quick fix for these issue, and I recommend to publish a new patch version of ducktape before release 3.3.1 to allow for frictionless migration of ducktape users to newer version of compiler and to allow the Open Community Build to test  this project against next versions of the compiler
