### PR TITLE
dramatically simplify `ProductZipper`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ ThisBuild / startYear := Some(2023)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(tlGitHubDev("arainko", "Aleksander Rainko"))
 ThisBuild / tlSonatypeUseLegacyHost := false
-ThisBuild / scalaVersion := "3.3.1"
+ThisBuild / scalaVersion := "3.3.2"
 
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/FieldValue.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/FieldValue.scala
@@ -1,0 +1,17 @@
+package io.github.arainko.ducktape.internal
+
+import scala.quoted.*
+
+private[ducktape] enum FieldValue {
+  def name: String
+  def tpe: Type[?]
+
+  case Wrapped[F[+x]](name: String, tpe: Type[?], value: Expr[F[Any]])
+  case Unwrapped(name: String, tpe: Type[?], value: Expr[Any])
+}
+
+object FieldValue {
+  extension [F[+x]](wrapped: FieldValue.Wrapped[F]) {
+    def unwrapped(value: Expr[Any]): FieldValue.Unwrapped = FieldValue.Unwrapped(wrapped.name, wrapped.tpe, value)
+  }
+}

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/NonEmptyList.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/NonEmptyList.scala
@@ -19,7 +19,7 @@ private[ducktape] object NonEmptyList {
   private[ducktape] given [A: Debug]: Debug[NonEmptyList[A]] = Debug.collection[A, List]
 
   extension [A](self: NonEmptyList[A]) {
-    export toList.{ foldLeft, reduceLeft, head, tail, exists, filter, collect }
+    export toList.{ foldLeft, reduceLeft, head, tail, exists, filter, collect, toVector }
 
     private[ducktape] def toList: ::[A] = self
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/DerivedInstanceSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/DerivedInstanceSuite.scala
@@ -75,10 +75,10 @@ class DerivedInstanceSuite extends DucktapeSuite {
 
       val expected =
         Left(
-          "Invalid Talk.Name" ::
-            "Invalid Talk.ElevatorPitch" ::
+          "Invalid Presenter.Bio" ::
             "Invalid Presenter.Name" ::
-            "Invalid Presenter.Bio" ::
+            "Invalid Talk.ElevatorPitch" ::
+            "Invalid Talk.Name" ::
             Nil
         )
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/DerivedInstanceSuite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/fallible/accumulating/DerivedInstanceSuite.scala
@@ -75,10 +75,10 @@ class DerivedInstanceSuite extends DucktapeSuite {
 
       val expected =
         Left(
-          "Invalid Presenter.Bio" ::
-            "Invalid Presenter.Name" ::
+          "Invalid Talk.Name" ::
             "Invalid Talk.ElevatorPitch" ::
-            "Invalid Talk.Name" ::
+            "Invalid Presenter.Name" ::
+            "Invalid Presenter.Bio" ::
             Nil
         )
 


### PR DESCRIPTION
Change the mechanism of `ProductZipper` to produce tuple accessors instead of pattern matches