### PR TITLE
[Issue#165] reject calls to _.to and _.into.transform (and their fallible counterparts) in given Transformer definitions

### DIFF
--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/ErrorMessage.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/ErrorMessage.scala
@@ -94,4 +94,14 @@ private[ducktape] object ErrorMessage {
       "Case config's path should always end with an `.at` segment"
     val side: Side = Side.Source
   }
+
+  case object LoopingTransformerDetected extends ErrorMessage {
+    val side: Side = Side.Dest
+
+    def render(using Quotes): String =
+      "Detected usage of `_.to[B]`, `_.fallibleTo[B]`, `_.into[B].transform()` or `_.into[B].fallible.transform()` in a given Transformer definition which results in a self-looping Transformer. Please use `Transformer.define[A, B]` or `Transformer.define[A, B].fallible` (for some types A and B) to create Transformer definitions"
+
+    val span: Span | None.type = None
+  }
+
 }

--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/TransformationSite.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/TransformationSite.scala
@@ -8,6 +8,8 @@ private[ducktape] enum TransformationSite {
 }
 
 private[ducktape] object TransformationSite {
+  def current(using ts: TransformationSite): TransformationSite = ts
+
   def fromStringExpr(value: Expr["transformation" | "definition"])(using Quotes): TransformationSite = {
     import quotes.reflect.*
 

--- a/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue165Suite.scala
+++ b/ducktape/src/test/scala/io/github/arainko/ducktape/issues/Issue165Suite.scala
@@ -1,0 +1,57 @@
+package io.github.arainko.ducktape.issues
+
+import io.github.arainko.ducktape.*
+
+class Issue165Suite extends DucktapeSuite {
+  test("rejects _.to in given Transformer definitions") {
+    assertFailsToCompileWith {
+      """
+      case class A(a: Int)
+      case class B(b: Int)
+      given Transformer[A, B] = _.to[B]
+      """
+    }(
+      "Detected usage of `_.to[B]`, `_.fallibleTo[B]`, `_.into[B].transform()` or `_.into[B].fallible.transform()` in a given Transformer definition which results in a self-looping Transformer. Please use `Transformer.define[A, B]` or `Transformer.define[A, B].fallible` (for some types A and B) to create Transformer definitions @ B"
+    )
+  }
+
+  test("rejects _.into.transform() in given Transformer definitions") {
+    assertFailsToCompileWith {
+      """
+      case class A(a: Int)
+      case class B(b: Int)
+      given Transformer[A, B] = _.into[B].transform()
+      """
+    }(
+      "Detected usage of `_.to[B]`, `_.fallibleTo[B]`, `_.into[B].transform()` or `_.into[B].fallible.transform()` in a given Transformer definition which results in a self-looping Transformer. Please use `Transformer.define[A, B]` or `Transformer.define[A, B].fallible` (for some types A and B) to create Transformer definitions @ B"
+    )
+  }
+
+  test("rejects _.falibleTo in given Trasformer.Fallible definitions") {
+    assertFailsToCompileWith {
+      """
+      given Mode.FailFast.Option with {}
+
+      case class A(a: Int)
+      case class B(b: Int)
+      given Transformer.Fallible[Option, A, B] = _.fallibleTo[B]
+      """
+    }(
+      "Detected usage of `_.to[B]`, `_.fallibleTo[B]`, `_.into[B].transform()` or `_.into[B].fallible.transform()` in a given Transformer definition which results in a self-looping Transformer. Please use `Transformer.define[A, B]` or `Transformer.define[A, B].fallible` (for some types A and B) to create Transformer definitions @ B"
+    )
+  }
+
+  test("rejects _.into.falible in given Trasformer.Fallible definitions") {
+    assertFailsToCompileWith {
+      """
+      given Mode.FailFast.Option with {}
+
+      case class A(a: Int)
+      case class B(b: Int)
+      given Transformer.Fallible[Option, A, B] = _.into[B].fallible.transform()
+      """
+    }(
+      "Detected usage of `_.to[B]`, `_.fallibleTo[B]`, `_.into[B].transform()` or `_.into[B].fallible.transform()` in a given Transformer definition which results in a self-looping Transformer. Please use `Transformer.define[A, B]` or `Transformer.define[A, B].fallible` (for some types A and B) to create Transformer definitions @ B"
+    )
+  }
+}


### PR DESCRIPTION
Fixes #165 