### PR TITLE
Make `Context.current` a transparent inline to make it work under Scala 3.4.+

### DIFF
--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/Context.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/Context.scala
@@ -15,7 +15,7 @@ private[ducktape] sealed trait Context {
 private[ducktape] object Context {
   type Of[F0 <: Fallible] = Context { type F = F0 }
 
-  inline def current(using ctx: Context): ctx.type = ctx
+  transparent inline def current(using ctx: Context): ctx.type = ctx
 
   case class PossiblyFallible[G[+x]](
     wrapperType: WrapperType.Wrapped[G],


### PR DESCRIPTION
It fixes compilation, and possibly usage for users of the `Context.current` due to https://github.com/scala/scala3/pull/19253
Issue spotted by Scala 3 Open Community Build - [logs](https://github.com/VirtusLab/community-build3/actions/runs/10058953806/job/27803320280)
Since 3.4.0 it would fail with: 
```scala
[error] -- [E172] Type Error: /Users/wmazur/projects/community-build3/repo/ducktape/src/main/scala/io/github/arainko/ducktape/internal/Planner.scala:274:32 
[error] 274 |          ctx.reifyPlan[F](plan)
[error]     |                                ^
[error]     |Cannot prove that io.github.arainko.ducktape.internal.Plan[
[error]     |  io.github.arainko.ducktape.internal.Erroneous, ctx.F] =:= io.github.arainko.ducktape.internal.Plan[
[error]     |  io.github.arainko.ducktape.internal.Erroneous, F²].
[error]     |
[error]     |where:    F  is a type in class PossiblyFallible which is an alias of io.github.arainko.ducktape.internal.Fallible
[error]     |          F² is a type in method unapply with bounds <: io.github.arainko.ducktape.internal.Fallible
[error] -- [E172] Type Error: /Users/wmazur/projects/community-build3/repo/ducktape/src/main/scala/io/github/arainko/ducktape/internal/Planner.scala:296:11 
[error] 296 |          }
[error]     |           ^
[error]     |Cannot prove that io.github.arainko.ducktape.internal.Plan[
[error]     |  io.github.arainko.ducktape.internal.Erroneous, ctx.F] =:= io.github.arainko.ducktape.internal.Plan[
[error]     |  io.github.arainko.ducktape.internal.Erroneous, F²].
[error]     |
[error]     |where:    F  is a type in class PossiblyFallible which is an alias of io.github.arainko.ducktape.internal.Fallible
[error]     |          F² is a type in method unapply with bounds <: io.github.arainko.ducktape.internal.Fallible
[error] -- [E172] Type Error: /Users/wmazur/projects/community-build3/repo/ducktape/src/main/scala/io/github/arainko/ducktape/internal/Planner.scala:315:11 
[error] 315 |          }
[error]     |           ^
[error]     |Cannot prove that io.github.arainko.ducktape.internal.Plan[
[error]     |  io.github.arainko.ducktape.internal.Erroneous, ctx.F] =:= io.github.arainko.ducktape.internal.Plan[
[error]     |  io.github.arainko.ducktape.internal.Erroneous, F²].
[error]     |
[error]     |where:    F  is a type in class PossiblyFallible which is an alias of io.github.arainko.ducktape.internal.Fallible
[error]     |          F² is a type in method unapply with bounds <: io.github.arainko.ducktape.internal.Fallible
```

The constraint might be also applicable for other `current` methods used to summon implicit, eg. `Mode.current` but I've not spotted any problems with it so far