### PR TITLE
[issue #319] use `value.accessFieldByName` instead of `.accessFieldByNameUnsafe` 

### DIFF
--- a/ducktape/src/main/scala/io/github/arainko/ducktape/internal/PlanInterpreter.scala
+++ b/ducktape/src/main/scala/io/github/arainko/ducktape/internal/PlanInterpreter.scala
@@ -36,7 +36,7 @@ private[ducktape] object PlanInterpreter {
       case Plan.BetweenProductTuple(source, dest, plans) =>
         val args = plans.map {
           case FieldPlan(fieldName: String, plan) =>
-            val fieldValue = value.accessFieldByNameUnsafe(fieldName).asExpr
+            val fieldValue = value.accessFieldByName(fieldName, source).asExpr
             recurse(plan, fieldValue)
           case FieldPlan(None, plan) =>
             recurse(plan, value)

--- a/scala-next-tests/src/test/scala/io/github/arainko/ducktape/NamedTupleSuite.scala
+++ b/scala-next-tests/src/test/scala/io/github/arainko/ducktape/NamedTupleSuite.scala
@@ -356,4 +356,12 @@ class NamedTupleSuite extends DucktapeSuite {
       Field.allMatching(fieldSource)
     )
   }
+
+  test("named tuple to tuple works") {
+    assertTransforms((a = 1, b = 2, c = 3), (1, 2, 3))
+  }
+
+  test("tuple to named tuple works") {
+    assertTransforms((1, 2, 3), (a = 1, b = 2, c = 3))
+  }
 }


### PR DESCRIPTION
it's right in the name smh

fixes #319 